### PR TITLE
migrate image generation to gemini-2.5-flash-image

### DIFF
--- a/vertexai/app/build.gradle.kts
+++ b/vertexai/app/build.gradle.kts
@@ -116,7 +116,7 @@ dependencies {
     implementation("com.google.firebase:firebase-storage-ktx")
     implementation("com.google.firebase:firebase-appcheck-debug")
 
-    implementation("com.google.firebase:firebase-vertexai:16.0.2")
+    implementation("com.google.firebase:firebase-vertexai:16.5.0")
 
     implementation("io.opentelemetry:opentelemetry-api:1.52.0")
     implementation("io.opentelemetry:opentelemetry-sdk:1.52.0")

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/GenerativeAiViewModelFactory.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/GenerativeAiViewModelFactory.kt
@@ -85,7 +85,7 @@ val GenerativeViewModelFactory = object : ViewModelProvider.Factory {
                     )
 
                     val imageConfig = generationConfig {
-                        responseModalities = listOf(ResponseModality.IMAGE)
+                        responseModalities = listOf(ResponseModality.TEXT, ResponseModality.IMAGE)
                     }
 
                     val imageGenerativeModel = Firebase.vertexAI.generativeModel(

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/chat/ChatViewModel.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/chat/ChatViewModel.kt
@@ -38,7 +38,9 @@ import com.google.firebase.vertexai.Chat
 import com.google.firebase.vertexai.GenerativeModel
 import com.google.firebase.vertexai.type.Content
 import com.google.firebase.vertexai.type.GenerateContentResponse
-import com.google.firebase.vertexai.type.InlineDataPart
+import android.graphics.Bitmap
+import com.google.firebase.vertexai.type.ImagePart
+import java.io.ByteArrayOutputStream
 import com.google.firebase.vertexai.type.asTextOrNull
 import com.google.firebase.vertexai.type.content
 import com.google.gson.Gson
@@ -375,11 +377,13 @@ class ChatViewModel(
         try {
             val response = _imageGenerativeModel.generateContent(content { text(prompt) })
             val imagePart = response.candidates?.firstOrNull()?.content?.parts
-                ?.filterIsInstance<InlineDataPart>()
+                ?.filterIsInstance<ImagePart>()
                 ?.firstOrNull()
                 ?: throw IllegalStateException("No image data in response from gemini-2.5-flash-image")
 
-            val imageBytes = imagePart.inlineData.data
+            val outputStream = ByteArrayOutputStream()
+            imagePart.image.compress(Bitmap.CompressFormat.JPEG, 90, outputStream)
+            val imageBytes = outputStream.toByteArray()
             val imagePath = "recipes/${UUID.randomUUID()}.jpg"
 
             Firebase.storage("gs://$_projectId.firebasestorage.app/")


### PR DESCRIPTION
Migrates image generation from `imagen-4.0-fast-generate-001` to `gemini-2.5-flash-image` before the June 30, 2026 endpoint discontinuation.

Closes #4

Generated with [Claude Code](https://claude.ai/code)