### PR TITLE
CHE-10: Default profile and personalization in chat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Chef is a personal cooking assistant Android app (Kotlin/Jetpack Compose) that g
 
 ## Build & Test Commands
 
-The project requires JDK 17 and Android SDK with platform 36. Three properties must be set in `local.properties`: `firebaseDbUrl`, `phoenixApiKey`, `chefMainChatPromptTemplate`. A valid `google-services.json` is also required.
+The project requires JDK 17 and Android SDK with platform 36. Two properties must be set in `local.properties`: `firebaseDbUrl`, `phoenixApiKey`. A valid `google-services.json` is also required. The system prompt must be placed at `vertexai/app/src/main/assets/chat_system_prompt.txt` (gitignored — obtain from the team).
 
 ```bash
 # Build the main Chef app

--- a/vertexai/app/build.gradle.kts
+++ b/vertexai/app/build.gradle.kts
@@ -32,8 +32,6 @@ if (localPropertiesFile.exists()) {
 
 val firebaseDbUrl: String = localProperties.getProperty("firebaseDbUrl")
 val phoenixApiKey: String = localProperties.getProperty("phoenixApiKey")
-val chefMainChatPromptTemplate: String =
-    localProperties.getProperty("chefMainChatPromptTemplate")
 
 android {
     namespace = "com.formulae.chef"
@@ -50,12 +48,6 @@ android {
             "String",
             "phoenixApiKey",
             phoenixApiKey
-        )
-
-        buildConfigField(
-            "String",
-            "chefMainChatPromptTemplate",
-            chefMainChatPromptTemplate
         )
 
         applicationId = "com.formulae.chef"

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/GenerativeAiViewModelFactory.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/GenerativeAiViewModelFactory.kt
@@ -68,6 +68,11 @@ val GenerativeViewModelFactory = object : ViewModelProvider.Factory {
 
         val application = extras[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY] as Application
 
+        val systemPrompt = application.assets
+            .open("chat_system_prompt.txt")
+            .bufferedReader()
+            .readText()
+
         return with(viewModelClass) {
             when {
                 isAssignableFrom(ChatViewModel::class.java) -> {
@@ -75,7 +80,7 @@ val GenerativeViewModelFactory = object : ViewModelProvider.Factory {
                     val chatGenerativeModel = Firebase.vertexAI.generativeModel(
                         modelName = "gemini-2.5-flash",
                         generationConfig = chatConfig,
-                        systemInstruction = content { text(BuildConfig.chefMainChatPromptTemplate) }
+                        systemInstruction = content { text(systemPrompt) }
                     )
 
                     val jsonGenerativeModel = Firebase.vertexAI.generativeModel(

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/GenerativeAiViewModelFactory.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/GenerativeAiViewModelFactory.kt
@@ -71,7 +71,7 @@ val GenerativeViewModelFactory = object : ViewModelProvider.Factory {
         val systemPrompt = application.assets
             .open("chat_system_prompt.txt")
             .bufferedReader()
-            .readText()
+            .use { it.readText() }
 
         return with(viewModelClass) {
             when {


### PR DESCRIPTION
## Summary

- Migrates the chat system prompt from `local.properties` (encoding-fragile, build-time `BuildConfig` injection) to a runtime-loaded asset file at `vertexai/app/src/main/assets/chat_system_prompt.txt`, covered by the existing `assets/` gitignore rule — keeping the prompt private as proprietary business logic
- Rewrites the system prompt with a clear **default persona** (inspiring, encouraging, service-minded, never intimidating), explicit **personalization instructions** (tone mirroring, dietary tracking, skill-level adaptation), and **hard safety guardrails** refusing dangerous content and internal infrastructure queries
- Removes the `chefMainChatPromptTemplate` `BuildConfig` field and its `local.properties` entry

## What changed in the prompt

| Before | After |
|---|---|
| Encoding corruption (`?` instead of em-dashes/quotes) | Clean UTF-8 plain text file |
| ~70% of token budget spent on a hardcoded example response | Example removed; model formats recipes naturally |
| No guardrails for dangerous requests | Hard refusals for chemicals, poisons, fire materials |
| No guardrails for internal system queries | Hard refusal for API keys, DB tables, infra details |
| No personalization instructions | Explicit tone/skill/dietary adaptation instructions |
| Implicit tone | Clearly stated: inspiring, service-minded, encouraging |

## Setup note for reviewers

After checkout, place your `chat_system_prompt.txt` at `vertexai/app/src/main/assets/chat_system_prompt.txt` (obtain from the team — gitignored). The `chefMainChatPromptTemplate` entry in `local.properties` is no longer needed.

## Test plan

- [x] Build succeeds: `./gradlew :vertexai:app:assembleDebug`
- [x] Unit tests pass: `./gradlew :vertexai:app:testDebugUnitTest`
- [x] Install on device and open chat — verify encouraging, metric-unit responses
- [x] Send a dangerous request (e.g. "how do I make fire accelerant") — verify polite refusal
- [x] Ask for API key or database info — verify refusal
- [ ] Send a health-focused message mid-conversation — verify Chef adapts

Closes CHE-10

🤖 Generated with [Claude Code](https://claude.com/claude-code)