### PR TITLE
fix(chat): add granular logging to image generation pipeline

### DIFF
--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/chat/ChatViewModel.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/chat/ChatViewModel.kt
@@ -401,10 +401,13 @@ class ChatViewModel(
     }
 
     private suspend fun createImageForRecipeAsync(recipe: String): String {
+        Log.d("ChatViewModel", "Starting image generation pipeline")
         val gcsUri = generateImageInstrumented(recipe)
+        Log.d("ChatViewModel", "Image generated and uploaded, fetching download URL")
         val storagePath = gcsUri.removePrefix("gs://$_projectId.firebasestorage.app/")
         val downloadUrl = Firebase.storage("gs://$_projectId.firebasestorage.app/")
             .reference.child(storagePath).downloadUrl.await()
+        Log.d("ChatViewModel", "Download URL obtained successfully")
         return "https://" + downloadUrl.host + downloadUrl.encodedPath + "?alt=media"
     }
 
@@ -488,7 +491,11 @@ class ChatViewModel(
             val imageUrl = try {
                 createImageForRecipeAsync(recipe.toString())
             } catch (e: Exception) {
-                Log.e("ChatViewModel", "Failed to generate image for ${recipe.title}", e)
+                Log.e(
+                    "ChatViewModel",
+                    "Image generation pipeline failed for '${recipe.title}' [${e.javaClass.simpleName}: ${e.message}]",
+                    e
+                )
                 null
             }
             recipe.copyOf(imageUrl = imageUrl)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Added step-level `Log.d` calls in `createImageForRecipeAsync` to show pipeline progress in logcat (entry, after image gen/upload, after Firebase Storage download URL fetch)
- Enhanced the catch log in `deriveRecipesFromMessage` to include exception class name and message inline, making it easier to triage failures from logcat without parsing the full stack trace

## Reviewer Notes

No behavior changes — logging only. The gitignored `chat_system_prompt.txt`, `gcp.json`, `imagen-google-services.json`, and `google-services.json` are required to build and run the app.

## Test Plan

- [x] `ktlintCheck` passes
- [x] `assembleDebug` builds successfully
- [x] Unit tests pass (`testDebugUnitTest`)
- [x] Manual E2E: star a recipe from chat and verify `D/ChatViewModel` pipeline steps appear in logcat

Closes #11
EOF
)