### PR TITLE
feat(collection): recipe variants (CHE-14)

### DIFF
--- a/vertexai/app/src/main/kotlin/com/formulae/chef/AppNavigation.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/AppNavigation.kt
@@ -1,6 +1,7 @@
 package com.formulae.chef
 
 import androidx.compose.runtime.Composable
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -10,6 +11,7 @@ import com.formulae.chef.feature.useraccount.ui.SignInRoute
 import com.formulae.chef.services.authentication.UserSessionService
 import com.formulae.chef.services.persistence.RecipeListRepository
 import com.formulae.chef.services.persistence.RecipeRepository
+import com.formulae.chef.services.persistence.RecipeVariantRepositoryImpl
 
 @Composable
 fun AppNavigation(
@@ -17,6 +19,7 @@ fun AppNavigation(
     recipeListRepository: RecipeListRepository,
     userSessionService: UserSessionService
 ) {
+    val recipeVariantRepository = RecipeVariantRepositoryImpl()
     val navController = rememberNavController()
 
     NavHost(navController = navController, startDestination = "home") {
@@ -39,6 +42,13 @@ fun AppNavigation(
             CollectionRoute(
                 repository = recipeRepository,
                 listRepository = recipeListRepository,
+                collectionViewModel = viewModel(
+                    factory = CollectionViewModelFactory(
+                        recipeRepository,
+                        recipeListRepository,
+                        recipeVariantRepository
+                    )
+                ),
                 navController = navController,
                 userSessionService = userSessionService
             )

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/AppNavigation.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/AppNavigation.kt
@@ -11,15 +11,15 @@ import com.formulae.chef.feature.useraccount.ui.SignInRoute
 import com.formulae.chef.services.authentication.UserSessionService
 import com.formulae.chef.services.persistence.RecipeListRepository
 import com.formulae.chef.services.persistence.RecipeRepository
-import com.formulae.chef.services.persistence.RecipeVariantRepositoryImpl
+import com.formulae.chef.services.persistence.RecipeVariantRepository
 
 @Composable
 fun AppNavigation(
     recipeRepository: RecipeRepository,
     recipeListRepository: RecipeListRepository,
+    recipeVariantRepository: RecipeVariantRepository,
     userSessionService: UserSessionService
 ) {
-    val recipeVariantRepository = RecipeVariantRepositoryImpl()
     val navController = rememberNavController()
 
     NavHost(navController = navController, startDestination = "home") {

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/CollectionViewModelFactory.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/CollectionViewModelFactory.kt
@@ -5,15 +5,17 @@ import androidx.lifecycle.ViewModelProvider
 import com.formulae.chef.feature.collection.CollectionViewModel
 import com.formulae.chef.services.persistence.RecipeListRepository
 import com.formulae.chef.services.persistence.RecipeRepository
+import com.formulae.chef.services.persistence.RecipeVariantRepository
 
 class CollectionViewModelFactory(
     private val repository: RecipeRepository,
-    private val listRepository: RecipeListRepository
+    private val listRepository: RecipeListRepository,
+    private val variantRepository: RecipeVariantRepository
 ) : ViewModelProvider.Factory {
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(CollectionViewModel::class.java)) {
-            return CollectionViewModel(repository, listRepository) as T
+            return CollectionViewModel(repository, listRepository, variantRepository) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/MainActivity.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/MainActivity.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import com.formulae.chef.services.authentication.UserSessionServiceFirebaseImpl
 import com.formulae.chef.services.persistence.RecipeListRepositoryImpl
 import com.formulae.chef.services.persistence.RecipeRepositoryImpl
+import com.formulae.chef.services.persistence.RecipeVariantRepositoryImpl
 import com.formulae.chef.ui.theme.GenerativeAISample
 import com.google.firebase.Firebase
 import com.google.firebase.appcheck.appCheck
@@ -52,6 +53,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         val recipeRepository = RecipeRepositoryImpl()
         val recipeListRepository = RecipeListRepositoryImpl()
+        val recipeVariantRepository = RecipeVariantRepositoryImpl()
 
         this.actionBar?.hide()
 
@@ -89,7 +91,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    AppNavigation(recipeRepository, recipeListRepository, userSessionService)
+                    AppNavigation(recipeRepository, recipeListRepository, recipeVariantRepository, userSessionService)
                 }
             }
         }

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/CollectionViewModel.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/CollectionViewModel.kt
@@ -4,17 +4,24 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.formulae.chef.feature.model.Recipe
 import com.formulae.chef.feature.model.RecipeList
+import com.formulae.chef.feature.model.RecipeVariant
 import com.formulae.chef.feature.model.parsedServingsCount
 import com.formulae.chef.services.persistence.RecipeListRepository
 import com.formulae.chef.services.persistence.RecipeRepository
+import com.formulae.chef.services.persistence.RecipeVariantRepository
+import java.time.Instant
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 class CollectionViewModel(
     private val repository: RecipeRepository,
-    private val listRepository: RecipeListRepository
+    private val listRepository: RecipeListRepository,
+    private val variantRepository: RecipeVariantRepository
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(CollectionUiState())
     val uiState: StateFlow<CollectionUiState> = _uiState.asStateFlow()
@@ -42,6 +49,45 @@ class CollectionViewModel(
 
     private val _expandedListId = MutableStateFlow<String?>(null)
     val expandedListId: StateFlow<String?> = _expandedListId.asStateFlow()
+
+    private val _variants = MutableStateFlow<List<RecipeVariant>>(emptyList())
+    val variants: StateFlow<List<RecipeVariant>> = _variants.asStateFlow()
+
+    private val _selectedVariantId = MutableStateFlow<String?>(null)
+    val selectedVariantId: StateFlow<String?> = _selectedVariantId.asStateFlow()
+
+    private val _isEditingVariant = MutableStateFlow(false)
+    val isEditingVariant: StateFlow<Boolean> = _isEditingVariant.asStateFlow()
+
+    val displayedRecipe: StateFlow<Recipe?> = combine(
+        _selectedRecipe,
+        _variants,
+        _selectedVariantId
+    ) { recipe, variants, variantId ->
+        if (recipe == null || variantId == null) return@combine recipe
+        val variant = variants.find { it.id == variantId } ?: return@combine recipe
+        Recipe(
+            id = recipe.id,
+            uid = recipe.uid,
+            imageUrl = recipe.imageUrl,
+            isFavourite = recipe.isFavourite,
+            copyId = recipe.copyId,
+            tags = recipe.tags,
+            title = variant.title,
+            summary = variant.summary,
+            servings = variant.servings,
+            prepTime = variant.prepTime,
+            cookingTime = variant.cookingTime,
+            nutrientsPerServing = variant.nutrientsPerServing,
+            ingredients = variant.ingredients,
+            difficulty = variant.difficulty,
+            instructions = variant.instructions,
+            tipsAndTricks = variant.tipsAndTricks,
+            updatedAt = variant.createdAt
+        )
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    val isRecipeOwner: Boolean get() = _selectedRecipe.value?.uid == currentUid
 
     private var recipes: List<Recipe> = emptyList()
     private var cookingRecipeId: String? = null
@@ -126,6 +172,18 @@ class CollectionViewModel(
             cookingRecipeId = null
         }
         _selectedRecipe.value = recipe
+        _variants.value = emptyList()
+        _selectedVariantId.value = null
+
+        recipe.id?.let { recipeId ->
+            viewModelScope.launch {
+                val loaded = variantRepository.loadVariantsForRecipe(recipeId)
+                _variants.value = loaded
+                if (isRecipeOwner) {
+                    _selectedVariantId.value = loaded.firstOrNull { it.isPinned }?.id
+                }
+            }
+        }
     }
 
     fun onRecipeRemove(recipe: Recipe) {
@@ -138,6 +196,7 @@ class CollectionViewModel(
         _selectedRecipe.value = null
         recipes = recipes.filter { it.id != recipeId }
         _uiState.value = CollectionUiState(recipes = recipes)
+        resetVariantState()
     }
 
     fun onToggleCookingMode() {
@@ -145,7 +204,7 @@ class CollectionViewModel(
         _isCookingMode.value = entering
         if (entering) {
             cookingRecipeId = _selectedRecipe.value?.id
-            _currentServings.value = _selectedRecipe.value?.parsedServingsCount()
+            _currentServings.value = displayedRecipe.value?.parsedServingsCount()
             _checkedSteps.value = emptySet()
         } else {
             cookingRecipeId = null
@@ -172,6 +231,92 @@ class CollectionViewModel(
 
     fun clearSelectedRecipe() {
         _selectedRecipe.value = null
+        resetVariantState()
+    }
+
+    fun onVariantSelected(variantId: String?) {
+        if (variantId != _selectedVariantId.value) {
+            _isCookingMode.value = false
+            _checkedSteps.value = emptySet()
+            _currentServings.value = null
+        }
+        _selectedVariantId.value = variantId
+    }
+
+    fun onPinVariant(variantId: String?) {
+        val recipeId = _selectedRecipe.value?.id ?: return
+        val previouslyPinned = _variants.value.firstOrNull { it.isPinned }
+
+        if (previouslyPinned != null && previouslyPinned.id != variantId) {
+            previouslyPinned.id?.let { prevId ->
+                variantRepository.updateVariantIsPinned(recipeId, prevId, false)
+            }
+        }
+
+        if (variantId != null) {
+            variantRepository.updateVariantIsPinned(recipeId, variantId, true)
+        }
+
+        _variants.value = _variants.value.map { variant ->
+            when (variant.id) {
+                variantId -> variant.copy(isPinned = true)
+                else -> if (variant.isPinned) variant.copy(isPinned = false) else variant
+            }
+        }
+    }
+
+    fun onDeleteVariant(variantId: String) {
+        val recipeId = _selectedRecipe.value?.id ?: return
+        variantRepository.deleteVariant(recipeId, variantId)
+        _variants.value = _variants.value.filter { it.id != variantId }
+        if (_selectedVariantId.value == variantId) {
+            _selectedVariantId.value = null
+        }
+    }
+
+    fun onStartCreateVariant() {
+        _isEditingVariant.value = true
+    }
+
+    fun onSaveVariant(label: String, recipe: Recipe) {
+        val recipeId = _selectedRecipe.value?.id ?: return
+        val variant = RecipeVariant(
+            label = label,
+            createdAt = Instant.now().toString(),
+            isPinned = false,
+            title = recipe.title,
+            summary = recipe.summary,
+            servings = recipe.servings,
+            prepTime = recipe.prepTime,
+            cookingTime = recipe.cookingTime,
+            nutrientsPerServing = recipe.nutrientsPerServing,
+            ingredients = recipe.ingredients,
+            difficulty = recipe.difficulty,
+            instructions = recipe.instructions,
+            tipsAndTricks = recipe.tipsAndTricks
+        )
+        variantRepository.saveVariant(recipeId, variant)
+        _isEditingVariant.value = false
+
+        // Reload to get Firebase-assigned id
+        viewModelScope.launch {
+            val reloaded = variantRepository.loadVariantsForRecipe(recipeId)
+            _variants.value = reloaded
+            val newVariant = reloaded
+                .filter { it.label == label }
+                .maxByOrNull { it.createdAt }
+            _selectedVariantId.value = newVariant?.id
+        }
+    }
+
+    fun onCancelEditVariant() {
+        _isEditingVariant.value = false
+    }
+
+    private fun resetVariantState() {
+        _variants.value = emptyList()
+        _selectedVariantId.value = null
+        _isEditingVariant.value = false
     }
 
     data class CollectionUiState(

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/CollectionViewModel.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/CollectionViewModel.kt
@@ -295,17 +295,11 @@ class CollectionViewModel(
             instructions = recipe.instructions,
             tipsAndTricks = recipe.tipsAndTricks
         )
-        variantRepository.saveVariant(recipeId, variant)
-        _isEditingVariant.value = false
-
-        // Reload to get Firebase-assigned id
         viewModelScope.launch {
-            val reloaded = variantRepository.loadVariantsForRecipe(recipeId)
-            _variants.value = reloaded
-            val newVariant = reloaded
-                .filter { it.label == label }
-                .maxByOrNull { it.createdAt }
-            _selectedVariantId.value = newVariant?.id
+            val newId = variantRepository.saveVariant(recipeId, variant)
+            _variants.value = _variants.value + variant.copy(id = newId)
+            _selectedVariantId.value = newId
+            _isEditingVariant.value = false
         }
     }
 

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/CollectionScreen.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/CollectionScreen.kt
@@ -241,6 +241,7 @@ internal fun CollectionRoute(
                     onServingsChanged = collectionViewModel::onServingsChanged,
                     onVariantSelected = collectionViewModel::onVariantSelected,
                     onPinVariant = collectionViewModel::onPinVariant,
+                    onDeleteVariant = collectionViewModel::onDeleteVariant,
                     onStartCreateVariant = collectionViewModel::onStartCreateVariant
                 )
             }

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/CollectionScreen.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/CollectionScreen.kt
@@ -79,7 +79,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import coil.compose.rememberAsyncImagePainter
-import com.formulae.chef.CollectionViewModelFactory
 import com.formulae.chef.OverlayChatViewModelFactory
 import com.formulae.chef.R
 import com.formulae.chef.feature.chat.OverlayChatViewModel
@@ -102,9 +101,7 @@ enum class RecipeSource {
 internal fun CollectionRoute(
     repository: RecipeRepository,
     listRepository: RecipeListRepository,
-    collectionViewModel: CollectionViewModel = viewModel(
-        factory = CollectionViewModelFactory(repository, listRepository)
-    ),
+    collectionViewModel: CollectionViewModel,
     navController: NavController,
     userSessionService: UserSessionService
 ) {
@@ -112,12 +109,16 @@ internal fun CollectionRoute(
     val isLoading by collectionViewModel.isLoading.collectAsState()
     val listState = rememberLazyListState()
     val selectedRecipe by collectionViewModel.selectedRecipe.collectAsState()
+    val displayedRecipe by collectionViewModel.displayedRecipe.collectAsState()
     val isCookingMode by collectionViewModel.isCookingMode.collectAsState()
     val showIngredients by collectionViewModel.showIngredients.collectAsState()
     val checkedSteps by collectionViewModel.checkedSteps.collectAsState()
     val currentServings by collectionViewModel.currentServings.collectAsState()
     val lists by collectionViewModel.lists.collectAsState()
     val expandedListId by collectionViewModel.expandedListId.collectAsState()
+    val variants by collectionViewModel.variants.collectAsState()
+    val selectedVariantId by collectionViewModel.selectedVariantId.collectAsState()
+    val isEditingVariant by collectionViewModel.isEditingVariant.collectAsState()
     var searchQuery by rememberSaveable { mutableStateOf("") }
     val currentUser by produceState<UserInfo?>(initialValue = null) {
         if (!userSessionService.anonymousSession) {
@@ -215,20 +216,32 @@ internal fun CollectionRoute(
                     onRemoveRecipeFromList = collectionViewModel::onRemoveRecipeFromList,
                     listNamesForRecipe = ::listNamesForRecipe
                 )
+            } else if (isEditingVariant && displayedRecipe != null) {
+                EditVariantScreen(
+                    baseRecipe = displayedRecipe!!,
+                    onSave = collectionViewModel::onSaveVariant,
+                    onCancel = collectionViewModel::onCancelEditVariant
+                )
             } else {
                 DetailRoute(
-                    recipe = selectedRecipe!!,
+                    recipe = displayedRecipe ?: selectedRecipe!!,
                     onBack = { collectionViewModel.clearSelectedRecipe() },
                     isCookingMode = isCookingMode,
                     showIngredients = showIngredients,
                     checkedSteps = checkedSteps,
                     currentServings = currentServings,
                     listNames = listNamesForRecipe(selectedRecipe!!),
+                    variants = variants,
+                    selectedVariantId = selectedVariantId,
+                    isOwner = collectionViewModel.isRecipeOwner,
                     onToggleCookingMode = collectionViewModel::onToggleCookingMode,
                     onTabChanged = collectionViewModel::onTabChanged,
                     onStepChecked = collectionViewModel::onStepChecked,
                     onStepUnchecked = collectionViewModel::onStepUnchecked,
-                    onServingsChanged = collectionViewModel::onServingsChanged
+                    onServingsChanged = collectionViewModel::onServingsChanged,
+                    onVariantSelected = collectionViewModel::onVariantSelected,
+                    onPinVariant = collectionViewModel::onPinVariant,
+                    onStartCreateVariant = collectionViewModel::onStartCreateVariant
                 )
             }
         }

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/DetailScreen.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/DetailScreen.kt
@@ -59,6 +59,7 @@ import com.formulae.chef.feature.model.Difficulty
 import com.formulae.chef.feature.model.Ingredient
 import com.formulae.chef.feature.model.Nutrient
 import com.formulae.chef.feature.model.Recipe
+import com.formulae.chef.feature.model.RecipeVariant
 import com.formulae.chef.services.voice.AudioPlayer
 import com.formulae.chef.services.voice.GcpTextToSpeechService
 import com.formulae.chef.services.voice.buildTtsFlow
@@ -72,11 +73,17 @@ internal fun DetailRoute(
     checkedSteps: Set<Int> = emptySet(),
     currentServings: Int? = null,
     listNames: List<String> = emptyList(),
+    variants: List<RecipeVariant> = emptyList(),
+    selectedVariantId: String? = null,
+    isOwner: Boolean = false,
     onToggleCookingMode: () -> Unit = {},
     onTabChanged: (Boolean) -> Unit = {},
     onStepChecked: (Int) -> Unit = {},
     onStepUnchecked: (Int) -> Unit = {},
-    onServingsChanged: (Int) -> Unit = {}
+    onServingsChanged: (Int) -> Unit = {},
+    onVariantSelected: (String?) -> Unit = {},
+    onPinVariant: (String?) -> Unit = {},
+    onStartCreateVariant: () -> Unit = {}
 ) {
     BackHandler { onBack() }
     CreateDetailScreen(
@@ -86,11 +93,17 @@ internal fun DetailRoute(
         checkedSteps = checkedSteps,
         currentServings = currentServings,
         listNames = listNames,
+        variants = variants,
+        selectedVariantId = selectedVariantId,
+        isOwner = isOwner,
         onToggleCookingMode = onToggleCookingMode,
         onTabChanged = onTabChanged,
         onStepChecked = onStepChecked,
         onStepUnchecked = onStepUnchecked,
-        onServingsChanged = onServingsChanged
+        onServingsChanged = onServingsChanged,
+        onVariantSelected = onVariantSelected,
+        onPinVariant = onPinVariant,
+        onStartCreateVariant = onStartCreateVariant
     )
 }
 
@@ -102,11 +115,17 @@ private fun CreateDetailScreen(
     checkedSteps: Set<Int>,
     currentServings: Int?,
     listNames: List<String> = emptyList(),
+    variants: List<RecipeVariant> = emptyList(),
+    selectedVariantId: String? = null,
+    isOwner: Boolean = false,
     onToggleCookingMode: () -> Unit,
     onTabChanged: (Boolean) -> Unit,
     onStepChecked: (Int) -> Unit,
     onStepUnchecked: (Int) -> Unit,
-    onServingsChanged: (Int) -> Unit
+    onServingsChanged: (Int) -> Unit,
+    onVariantSelected: (String?) -> Unit = {},
+    onPinVariant: (String?) -> Unit = {},
+    onStartCreateVariant: () -> Unit = {}
 ) {
     val scrollState = rememberScrollState()
     val hasImage = recipe.imageUrl?.isNotEmpty() ?: false
@@ -138,6 +157,17 @@ private fun CreateDetailScreen(
                     .clip(RoundedCornerShape(8.dp))
             )
         }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        VariantPickerRow(
+            variants = variants,
+            selectedVariantId = selectedVariantId,
+            isOwner = isOwner,
+            onVariantSelected = onVariantSelected,
+            onPinVariant = onPinVariant,
+            onCreateVariant = onStartCreateVariant
+        )
 
         Spacer(modifier = Modifier.height(8.dp))
 

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/DetailScreen.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/DetailScreen.kt
@@ -161,17 +161,19 @@ private fun CreateDetailScreen(
             )
         }
 
-        Spacer(modifier = Modifier.height(8.dp))
+        if (isOwner || variants.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(8.dp))
 
-        VariantPickerRow(
-            variants = variants,
-            selectedVariantId = selectedVariantId,
-            isOwner = isOwner,
-            onVariantSelected = onVariantSelected,
-            onPinVariant = onPinVariant,
-            onDeleteVariant = onDeleteVariant,
-            onCreateVariant = onStartCreateVariant
-        )
+            VariantPickerRow(
+                variants = variants,
+                selectedVariantId = selectedVariantId,
+                isOwner = isOwner,
+                onVariantSelected = onVariantSelected,
+                onPinVariant = onPinVariant,
+                onDeleteVariant = onDeleteVariant,
+                onCreateVariant = onStartCreateVariant
+            )
+        }
 
         Spacer(modifier = Modifier.height(8.dp))
 

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/DetailScreen.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/DetailScreen.kt
@@ -83,6 +83,7 @@ internal fun DetailRoute(
     onServingsChanged: (Int) -> Unit = {},
     onVariantSelected: (String?) -> Unit = {},
     onPinVariant: (String?) -> Unit = {},
+    onDeleteVariant: (String) -> Unit = {},
     onStartCreateVariant: () -> Unit = {}
 ) {
     BackHandler { onBack() }
@@ -103,6 +104,7 @@ internal fun DetailRoute(
         onServingsChanged = onServingsChanged,
         onVariantSelected = onVariantSelected,
         onPinVariant = onPinVariant,
+        onDeleteVariant = onDeleteVariant,
         onStartCreateVariant = onStartCreateVariant
     )
 }
@@ -125,6 +127,7 @@ private fun CreateDetailScreen(
     onServingsChanged: (Int) -> Unit,
     onVariantSelected: (String?) -> Unit = {},
     onPinVariant: (String?) -> Unit = {},
+    onDeleteVariant: (String) -> Unit = {},
     onStartCreateVariant: () -> Unit = {}
 ) {
     val scrollState = rememberScrollState()
@@ -166,6 +169,7 @@ private fun CreateDetailScreen(
             isOwner = isOwner,
             onVariantSelected = onVariantSelected,
             onPinVariant = onPinVariant,
+            onDeleteVariant = onDeleteVariant,
             onCreateVariant = onStartCreateVariant
         )
 

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/EditVariantScreen.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/EditVariantScreen.kt
@@ -1,0 +1,415 @@
+package com.formulae.chef.feature.collection.ui
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.unit.dp
+import com.formulae.chef.feature.model.Difficulty
+import com.formulae.chef.feature.model.Ingredient
+import com.formulae.chef.feature.model.Nutrient
+import com.formulae.chef.feature.model.Recipe
+
+@Composable
+internal fun EditVariantScreen(
+    baseRecipe: Recipe,
+    onSave: (label: String, recipe: Recipe) -> Unit,
+    onCancel: () -> Unit
+) {
+    BackHandler { onCancel() }
+
+    var label by rememberSaveable { mutableStateOf("") }
+    var title by rememberSaveable { mutableStateOf(baseRecipe.title) }
+    var summary by rememberSaveable { mutableStateOf(baseRecipe.summary) }
+    var servings by rememberSaveable { mutableStateOf(baseRecipe.servings ?: "") }
+    var prepTime by rememberSaveable { mutableStateOf(baseRecipe.prepTime ?: "") }
+    var cookingTime by rememberSaveable { mutableStateOf(baseRecipe.cookingTime ?: "") }
+    var tipsAndTricks by rememberSaveable { mutableStateOf(baseRecipe.tipsAndTricks ?: "") }
+    var difficulty by rememberSaveable { mutableStateOf(baseRecipe.difficulty ?: Difficulty.EASY) }
+
+    var ingredients by rememberSaveable {
+        mutableStateOf(
+            baseRecipe.ingredients.map { Triple(it.name ?: "", it.quantity ?: "", it.unit ?: "") }
+        )
+    }
+    var instructions by rememberSaveable {
+        mutableStateOf(baseRecipe.instructions.toList())
+    }
+    var nutrients by rememberSaveable {
+        mutableStateOf(
+            (baseRecipe.nutrientsPerServing ?: emptyList()).map {
+                Triple(it.name ?: "", it.quantity ?: "", it.unit ?: "")
+            }
+        )
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        Text("Create Variant", style = MaterialTheme.typography.headlineMedium)
+        Spacer(modifier = Modifier.height(12.dp))
+
+        OutlinedTextField(
+            value = label,
+            onValueChange = { label = it },
+            label = { Text("Variant name *") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions.Default.copy(capitalization = KeyboardCapitalization.Sentences),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+        Text("Recipe Details", style = MaterialTheme.typography.titleMedium)
+        Spacer(modifier = Modifier.height(8.dp))
+
+        OutlinedTextField(
+            value = title,
+            onValueChange = { title = it },
+            label = { Text("Title") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions.Default.copy(capitalization = KeyboardCapitalization.Sentences),
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        OutlinedTextField(
+            value = summary,
+            onValueChange = { summary = it },
+            label = { Text("Summary") },
+            minLines = 3,
+            keyboardOptions = KeyboardOptions.Default.copy(capitalization = KeyboardCapitalization.Sentences),
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            OutlinedTextField(
+                value = servings,
+                onValueChange = { servings = it },
+                label = { Text("Servings") },
+                singleLine = true,
+                modifier = Modifier.weight(1f)
+            )
+            OutlinedTextField(
+                value = prepTime,
+                onValueChange = { prepTime = it },
+                label = { Text("Prep time") },
+                singleLine = true,
+                modifier = Modifier.weight(1f)
+            )
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+
+        OutlinedTextField(
+            value = cookingTime,
+            onValueChange = { cookingTime = it },
+            label = { Text("Cooking time") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        DifficultyPicker(
+            selected = difficulty,
+            onSelected = { difficulty = it }
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        OutlinedTextField(
+            value = tipsAndTricks,
+            onValueChange = { tipsAndTricks = it },
+            label = { Text("Tips & Tricks") },
+            minLines = 2,
+            keyboardOptions = KeyboardOptions.Default.copy(capitalization = KeyboardCapitalization.Sentences),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        // Ingredients
+        Spacer(modifier = Modifier.height(16.dp))
+        Text("Ingredients", style = MaterialTheme.typography.titleMedium)
+        Spacer(modifier = Modifier.height(8.dp))
+        ingredients.forEachIndexed { index, (name, qty, unit) ->
+            IngredientEditRow(
+                name = name,
+                quantity = qty,
+                unit = unit,
+                onNameChange = {
+                    ingredients = ingredients.toMutableList().also { list ->
+                        list[index] = Triple(
+                            it,
+                            qty,
+                            unit
+                        )
+                    }
+                },
+                onQuantityChange = {
+                    ingredients = ingredients.toMutableList().also { list ->
+                        list[index] = Triple(
+                            name,
+                            it,
+                            unit
+                        )
+                    }
+                },
+                onUnitChange = {
+                    ingredients = ingredients.toMutableList().also { list ->
+                        list[index] = Triple(
+                            name,
+                            qty,
+                            it
+                        )
+                    }
+                },
+                onRemove = { ingredients = ingredients.toMutableList().also { list -> list.removeAt(index) } }
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+        }
+        TextButton(onClick = { ingredients = ingredients + Triple("", "", "") }) {
+            Text("+ Add ingredient")
+        }
+
+        // Instructions
+        Spacer(modifier = Modifier.height(16.dp))
+        Text("Instructions", style = MaterialTheme.typography.titleMedium)
+        Spacer(modifier = Modifier.height(8.dp))
+        instructions.forEachIndexed { index, step ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.Top
+            ) {
+                Text(
+                    text = "${index + 1}.",
+                    modifier = Modifier.padding(top = 16.dp, end = 8.dp),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                OutlinedTextField(
+                    value = step,
+                    onValueChange = { instructions = instructions.toMutableList().also { list -> list[index] = it } },
+                    label = { Text("Step ${index + 1}") },
+                    minLines = 2,
+                    keyboardOptions = KeyboardOptions.Default.copy(capitalization = KeyboardCapitalization.Sentences),
+                    modifier = Modifier.weight(1f)
+                )
+                IconButton(
+                    onClick = { instructions = instructions.toMutableList().also { list -> list.removeAt(index) } }
+                ) {
+                    Icon(Icons.Default.Delete, contentDescription = "Remove step", tint = Color.Red)
+                }
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+        }
+        TextButton(onClick = { instructions = instructions + "" }) {
+            Text("+ Add step")
+        }
+
+        // Nutrients
+        Spacer(modifier = Modifier.height(16.dp))
+        Text("Nutrients per Serving", style = MaterialTheme.typography.titleMedium)
+        Spacer(modifier = Modifier.height(8.dp))
+        nutrients.forEachIndexed { index, (name, qty, unit) ->
+            IngredientEditRow(
+                name = name,
+                quantity = qty,
+                unit = unit,
+                namePlaceholder = "Nutrient",
+                onNameChange = {
+                    nutrients = nutrients.toMutableList().also { list ->
+                        list[index] = Triple(
+                            it,
+                            qty,
+                            unit
+                        )
+                    }
+                },
+                onQuantityChange = {
+                    nutrients = nutrients.toMutableList().also { list ->
+                        list[index] = Triple(
+                            name,
+                            it,
+                            unit
+                        )
+                    }
+                },
+                onUnitChange = {
+                    nutrients = nutrients.toMutableList().also { list ->
+                        list[index] = Triple(
+                            name,
+                            qty,
+                            it
+                        )
+                    }
+                },
+                onRemove = { nutrients = nutrients.toMutableList().also { list -> list.removeAt(index) } }
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+        }
+        TextButton(onClick = { nutrients = nutrients + Triple("", "", "") }) {
+            Text("+ Add nutrient")
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Button(
+                onClick = onCancel,
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondary),
+                modifier = Modifier.weight(1f)
+            ) {
+                Text("Cancel")
+            }
+            Button(
+                onClick = {
+                    val editedRecipe = Recipe(
+                        id = baseRecipe.id,
+                        uid = baseRecipe.uid,
+                        imageUrl = baseRecipe.imageUrl,
+                        isFavourite = baseRecipe.isFavourite,
+                        copyId = baseRecipe.copyId,
+                        tags = baseRecipe.tags,
+                        title = title,
+                        summary = summary,
+                        servings = servings.ifBlank { null },
+                        prepTime = prepTime.ifBlank { null },
+                        cookingTime = cookingTime.ifBlank { null },
+                        tipsAndTricks = tipsAndTricks.ifBlank { null },
+                        difficulty = difficulty,
+                        ingredients = ingredients.map { (n, q, u) -> Ingredient(name = n, quantity = q, unit = u) },
+                        instructions = instructions.filter { it.isNotBlank() },
+                        nutrientsPerServing = nutrients.map { (n, q, u) -> Nutrient(name = n, quantity = q, unit = u) },
+                        updatedAt = baseRecipe.updatedAt
+                    )
+                    onSave(label.trim(), editedRecipe)
+                },
+                enabled = label.isNotBlank(),
+                modifier = Modifier.weight(1f)
+            ) {
+                Text("Save variant")
+            }
+        }
+
+        Spacer(modifier = Modifier.height(30.dp))
+    }
+}
+
+@Composable
+private fun IngredientEditRow(
+    name: String,
+    quantity: String,
+    unit: String,
+    namePlaceholder: String = "Ingredient",
+    onNameChange: (String) -> Unit,
+    onQuantityChange: (String) -> Unit,
+    onUnitChange: (String) -> Unit,
+    onRemove: () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        OutlinedTextField(
+            value = name,
+            onValueChange = onNameChange,
+            label = { Text(namePlaceholder) },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions.Default.copy(capitalization = KeyboardCapitalization.Sentences),
+            modifier = Modifier.weight(3f)
+        )
+        OutlinedTextField(
+            value = quantity,
+            onValueChange = onQuantityChange,
+            label = { Text("Qty") },
+            singleLine = true,
+            modifier = Modifier.weight(1.5f)
+        )
+        OutlinedTextField(
+            value = unit,
+            onValueChange = onUnitChange,
+            label = { Text("Unit") },
+            singleLine = true,
+            modifier = Modifier.weight(1.5f)
+        )
+        IconButton(onClick = onRemove) {
+            Icon(Icons.Default.Delete, contentDescription = "Remove", tint = Color.Red)
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DifficultyPicker(
+    selected: Difficulty,
+    onSelected: (Difficulty) -> Unit
+) {
+    var expanded by rememberSaveable { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it }
+    ) {
+        OutlinedTextField(
+            value = selected.name,
+            onValueChange = {},
+            readOnly = true,
+            label = { Text("Difficulty") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                .fillMaxWidth()
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            Difficulty.entries.forEach { diff ->
+                DropdownMenuItem(
+                    text = { Text(diff.name) },
+                    onClick = {
+                        onSelected(diff)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/VariantPickerRow.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/VariantPickerRow.kt
@@ -1,0 +1,155 @@
+package com.formulae.chef.feature.collection.ui
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.StarOutline
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.formulae.chef.feature.model.RecipeVariant
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun VariantPickerRow(
+    variants: List<RecipeVariant>,
+    selectedVariantId: String?,
+    isOwner: Boolean,
+    onVariantSelected: (String?) -> Unit,
+    onPinVariant: (String?) -> Unit,
+    onCreateVariant: () -> Unit
+) {
+    val sortedVariants = variants.sortedBy { it.label }
+    val selectedLabel = if (selectedVariantId == null) {
+        "Default"
+    } else {
+        sortedVariants.find { it.id == selectedVariantId }?.label ?: "Default"
+    }
+
+    var expanded by remember { mutableStateOf(false) }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = { expanded = it },
+            modifier = Modifier.weight(1f)
+        ) {
+            OutlinedTextField(
+                value = selectedLabel,
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("Variants") },
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                modifier = Modifier
+                    .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                    .fillMaxWidth()
+            )
+
+            ExposedDropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false }
+            ) {
+                // Default (canonical) item
+                val defaultPinned = sortedVariants.none { it.isPinned }
+                DropdownMenuItem(
+                    text = { Text("Default") },
+                    onClick = {
+                        onVariantSelected(null)
+                        expanded = false
+                    },
+                    trailingIcon = if (isOwner) {
+                        {
+                            IconButton(onClick = {
+                                if (!defaultPinned) onPinVariant(null)
+                                expanded = false
+                            }) {
+                                Icon(
+                                    imageVector = if (defaultPinned) Icons.Filled.Star else Icons.Outlined.StarOutline,
+                                    contentDescription = if (defaultPinned) "Default is pinned" else "Pin default",
+                                    tint = if (defaultPinned) {
+                                        MaterialTheme.colorScheme.primary
+                                    } else {
+                                        MaterialTheme.colorScheme.onSurfaceVariant
+                                    }
+                                )
+                            }
+                        }
+                    } else {
+                        null
+                    }
+                )
+
+                sortedVariants.forEach { variant ->
+                    DropdownMenuItem(
+                        text = { Text(variant.label) },
+                        onClick = {
+                            onVariantSelected(variant.id)
+                            expanded = false
+                        },
+                        trailingIcon = if (isOwner) {
+                            {
+                                IconButton(onClick = {
+                                    if (variant.isPinned) {
+                                        onPinVariant(null)
+                                    } else {
+                                        variant.id?.let { onPinVariant(it) }
+                                    }
+                                    expanded = false
+                                }) {
+                                    Icon(
+                                        imageVector = if (variant.isPinned) {
+                                            Icons.Filled.Star
+                                        } else {
+                                            Icons.Outlined.StarOutline
+                                        },
+                                        contentDescription = if (variant.isPinned) "Pinned" else "Pin this variant",
+                                        tint = if (variant.isPinned) {
+                                            MaterialTheme.colorScheme.primary
+                                        } else {
+                                            MaterialTheme.colorScheme.onSurfaceVariant
+                                        }
+                                    )
+                                }
+                            }
+                        } else {
+                            null
+                        }
+                    )
+                }
+            }
+        }
+
+        if (isOwner) {
+            IconButton(
+                onClick = onCreateVariant,
+                modifier = Modifier.padding(start = 4.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Add,
+                    contentDescription = "Create variant"
+                )
+            }
+        }
+    }
+}

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/VariantPickerRow.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/VariantPickerRow.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material3.DropdownMenuItem
@@ -35,6 +36,7 @@ internal fun VariantPickerRow(
     isOwner: Boolean,
     onVariantSelected: (String?) -> Unit,
     onPinVariant: (String?) -> Unit,
+    onDeleteVariant: (String) -> Unit,
     onCreateVariant: () -> Unit
 ) {
     val sortedVariants = variants.sortedBy { it.label }
@@ -109,27 +111,39 @@ internal fun VariantPickerRow(
                         },
                         trailingIcon = if (isOwner) {
                             {
-                                IconButton(onClick = {
-                                    if (variant.isPinned) {
-                                        onPinVariant(null)
-                                    } else {
-                                        variant.id?.let { onPinVariant(it) }
-                                    }
-                                    expanded = false
-                                }) {
-                                    Icon(
-                                        imageVector = if (variant.isPinned) {
-                                            Icons.Filled.Star
+                                Row {
+                                    IconButton(onClick = {
+                                        if (variant.isPinned) {
+                                            onPinVariant(null)
                                         } else {
-                                            Icons.Outlined.StarOutline
-                                        },
-                                        contentDescription = if (variant.isPinned) "Pinned" else "Pin this variant",
-                                        tint = if (variant.isPinned) {
-                                            MaterialTheme.colorScheme.primary
-                                        } else {
-                                            MaterialTheme.colorScheme.onSurfaceVariant
+                                            variant.id?.let { onPinVariant(it) }
                                         }
-                                    )
+                                        expanded = false
+                                    }) {
+                                        Icon(
+                                            imageVector = if (variant.isPinned) {
+                                                Icons.Filled.Star
+                                            } else {
+                                                Icons.Outlined.StarOutline
+                                            },
+                                            contentDescription = if (variant.isPinned) "Pinned" else "Pin this variant",
+                                            tint = if (variant.isPinned) {
+                                                MaterialTheme.colorScheme.primary
+                                            } else {
+                                                MaterialTheme.colorScheme.onSurfaceVariant
+                                            }
+                                        )
+                                    }
+                                    IconButton(onClick = {
+                                        variant.id?.let { onDeleteVariant(it) }
+                                        expanded = false
+                                    }) {
+                                        Icon(
+                                            imageVector = Icons.Default.Delete,
+                                            contentDescription = "Delete variant",
+                                            tint = MaterialTheme.colorScheme.error
+                                        )
+                                    }
                                 }
                             }
                         } else {

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/model/RecipeVariant.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/model/RecipeVariant.kt
@@ -1,0 +1,24 @@
+package com.formulae.chef.feature.model
+
+import com.google.firebase.database.PropertyName
+
+data class RecipeVariant(
+    var id: String? = null,
+    var label: String = "",
+    var createdAt: String = "",
+    @get:PropertyName("isPinned")
+    @set:PropertyName("isPinned")
+    var isPinned: Boolean = false,
+    var title: String = "",
+    var summary: String = "",
+    var servings: String? = "",
+    var prepTime: String? = null,
+    var cookingTime: String? = null,
+    var nutrientsPerServing: List<Nutrient>? = listOf(),
+    var ingredients: List<Ingredient> = listOf(),
+    @get:PropertyName("difficulty")
+    @set:PropertyName("difficulty")
+    var difficulty: Difficulty? = Difficulty.EASY,
+    var instructions: List<String> = listOf(),
+    var tipsAndTricks: String? = null
+)

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/services/persistence/RecipeVariantRepository.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/services/persistence/RecipeVariantRepository.kt
@@ -4,7 +4,7 @@ import com.formulae.chef.feature.model.RecipeVariant
 
 interface RecipeVariantRepository {
     suspend fun loadVariantsForRecipe(recipeId: String): List<RecipeVariant>
-    fun saveVariant(recipeId: String, variant: RecipeVariant)
+    suspend fun saveVariant(recipeId: String, variant: RecipeVariant): String
     fun updateVariantIsPinned(recipeId: String, variantId: String, isPinned: Boolean)
     fun deleteVariant(recipeId: String, variantId: String)
 }

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/services/persistence/RecipeVariantRepository.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/services/persistence/RecipeVariantRepository.kt
@@ -1,0 +1,10 @@
+package com.formulae.chef.services.persistence
+
+import com.formulae.chef.feature.model.RecipeVariant
+
+interface RecipeVariantRepository {
+    suspend fun loadVariantsForRecipe(recipeId: String): List<RecipeVariant>
+    fun saveVariant(recipeId: String, variant: RecipeVariant)
+    fun updateVariantIsPinned(recipeId: String, variantId: String, isPinned: Boolean)
+    fun deleteVariant(recipeId: String, variantId: String)
+}

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/services/persistence/RecipeVariantRepositoryImpl.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/services/persistence/RecipeVariantRepositoryImpl.kt
@@ -1,0 +1,61 @@
+package com.formulae.chef.services.persistence
+
+import android.util.Log
+import com.formulae.chef.feature.model.RecipeVariant
+import com.google.firebase.database.FirebaseDatabase
+import kotlinx.coroutines.tasks.await
+
+private const val RECIPE_VARIANTS_KEY = "recipe_variants"
+
+class RecipeVariantRepositoryImpl(
+    private val database: FirebaseDatabase = FirebaseInstance.database
+) : RecipeVariantRepository {
+
+    override suspend fun loadVariantsForRecipe(recipeId: String): List<RecipeVariant> {
+        return database.getReference(RECIPE_VARIANTS_KEY)
+            .child(recipeId)
+            .get()
+            .await()
+            .children
+            .mapNotNull { snapshot ->
+                snapshot.getValue(RecipeVariant::class.java)
+                    ?.copy(isPinned = snapshot.child("isPinned").getValue(Boolean::class.java) ?: false)
+            }
+    }
+
+    override fun saveVariant(recipeId: String, variant: RecipeVariant) {
+        val ref = database.getReference(RECIPE_VARIANTS_KEY).child(recipeId)
+        val newRef = ref.push()
+        val variantWithId = variant.copy(id = newRef.key)
+        newRef.setValue(variantWithId).addOnCompleteListener { task ->
+            if (task.isSuccessful) {
+                Log.d("FirebaseDB", "Variant ${newRef.key} saved successfully")
+            } else {
+                Log.e("FirebaseDB", "Failed to save variant", task.exception)
+            }
+        }
+    }
+
+    override fun updateVariantIsPinned(recipeId: String, variantId: String, isPinned: Boolean) {
+        database.getReference(RECIPE_VARIANTS_KEY)
+            .child(recipeId)
+            .child(variantId)
+            .updateChildren(mapOf("isPinned" to isPinned))
+            .addOnFailureListener { e ->
+                Log.e("FirebaseDB", "Failed to update isPinned for variant $variantId", e)
+            }
+    }
+
+    override fun deleteVariant(recipeId: String, variantId: String) {
+        database.getReference(RECIPE_VARIANTS_KEY)
+            .child(recipeId)
+            .child(variantId)
+            .removeValue()
+            .addOnSuccessListener {
+                Log.d("FirebaseDB", "Variant $variantId deleted successfully")
+            }
+            .addOnFailureListener { e ->
+                Log.e("FirebaseDB", "Failed to delete variant $variantId", e)
+            }
+    }
+}

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/services/persistence/RecipeVariantRepositoryImpl.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/services/persistence/RecipeVariantRepositoryImpl.kt
@@ -23,17 +23,13 @@ class RecipeVariantRepositoryImpl(
             }
     }
 
-    override fun saveVariant(recipeId: String, variant: RecipeVariant) {
+    override suspend fun saveVariant(recipeId: String, variant: RecipeVariant): String {
         val ref = database.getReference(RECIPE_VARIANTS_KEY).child(recipeId)
         val newRef = ref.push()
-        val variantWithId = variant.copy(id = newRef.key)
-        newRef.setValue(variantWithId).addOnCompleteListener { task ->
-            if (task.isSuccessful) {
-                Log.d("FirebaseDB", "Variant ${newRef.key} saved successfully")
-            } else {
-                Log.e("FirebaseDB", "Failed to save variant", task.exception)
-            }
-        }
+        val id = newRef.key ?: ""
+        newRef.setValue(variant.copy(id = id)).await()
+        Log.d("FirebaseDB", "Variant $id saved successfully")
+        return id
     }
 
     override fun updateVariantIsPinned(recipeId: String, variantId: String, isPinned: Boolean) {

--- a/vertexai/app/src/test/kotlin/com/formulae/chef/feature/collection/CollectionViewModelTest.kt
+++ b/vertexai/app/src/test/kotlin/com/formulae/chef/feature/collection/CollectionViewModelTest.kt
@@ -701,9 +701,11 @@ private class FakeRecipeVariantRepository(
     override suspend fun loadVariantsForRecipe(recipeId: String): List<RecipeVariant> =
         data[recipeId]?.toList() ?: emptyList()
 
-    override fun saveVariant(recipeId: String, variant: RecipeVariant) {
-        val stored = if (autoAssignIds) variant.copy(id = "generated-${idCounter++}") else variant
+    override suspend fun saveVariant(recipeId: String, variant: RecipeVariant): String {
+        val id = if (autoAssignIds) "generated-${idCounter++}" else variant.id ?: ""
+        val stored = variant.copy(id = id)
         data.getOrPut(recipeId) { mutableListOf() }.add(stored)
+        return id
     }
 
     override fun updateVariantIsPinned(recipeId: String, variantId: String, isPinned: Boolean) {

--- a/vertexai/app/src/test/kotlin/com/formulae/chef/feature/collection/CollectionViewModelTest.kt
+++ b/vertexai/app/src/test/kotlin/com/formulae/chef/feature/collection/CollectionViewModelTest.kt
@@ -2,8 +2,10 @@ package com.formulae.chef.feature.collection
 
 import com.formulae.chef.feature.model.Recipe
 import com.formulae.chef.feature.model.RecipeList
+import com.formulae.chef.feature.model.RecipeVariant
 import com.formulae.chef.services.persistence.RecipeListRepository
 import com.formulae.chef.services.persistence.RecipeRepository
+import com.formulae.chef.services.persistence.RecipeVariantRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -40,10 +42,19 @@ class CollectionViewModelTest {
         Dispatchers.resetMain()
     }
 
+    private fun makeViewModel(
+        recipes: List<Recipe> = sampleRecipes,
+        variants: Map<String, List<RecipeVariant>> = emptyMap(),
+        listRepo: FakeRecipeListRepository = FakeRecipeListRepository()
+    ): Pair<CollectionViewModel, FakeRecipeVariantRepository> {
+        val variantRepo = FakeRecipeVariantRepository(variants)
+        return CollectionViewModel(FakeRecipeRepository(recipes), listRepo, variantRepo) to variantRepo
+    }
+
     @Test
     fun `init loads recipes from repository`() = runTest(testDispatcher) {
         val repository = FakeRecipeRepository(sampleRecipes)
-        val viewModel = CollectionViewModel(repository, FakeRecipeListRepository())
+        val viewModel = CollectionViewModel(repository, FakeRecipeListRepository(), FakeRecipeVariantRepository())
 
         advanceUntilIdle()
 
@@ -54,7 +65,7 @@ class CollectionViewModelTest {
     @Test
     fun `init with empty repository produces empty state`() = runTest(testDispatcher) {
         val repository = FakeRecipeRepository(emptyList())
-        val viewModel = CollectionViewModel(repository, FakeRecipeListRepository())
+        val viewModel = CollectionViewModel(repository, FakeRecipeListRepository(), FakeRecipeVariantRepository())
 
         advanceUntilIdle()
 
@@ -64,7 +75,7 @@ class CollectionViewModelTest {
     @Test
     fun `onRecipeSelected updates selectedRecipe`() = runTest(testDispatcher) {
         val repository = FakeRecipeRepository(sampleRecipes)
-        val viewModel = CollectionViewModel(repository, FakeRecipeListRepository())
+        val viewModel = CollectionViewModel(repository, FakeRecipeListRepository(), FakeRecipeVariantRepository())
         advanceUntilIdle()
 
         val recipe = sampleRecipes[1]
@@ -76,7 +87,7 @@ class CollectionViewModelTest {
     @Test
     fun `selectedRecipe is initially null`() = runTest(testDispatcher) {
         val repository = FakeRecipeRepository(sampleRecipes)
-        val viewModel = CollectionViewModel(repository, FakeRecipeListRepository())
+        val viewModel = CollectionViewModel(repository, FakeRecipeListRepository(), FakeRecipeVariantRepository())
         advanceUntilIdle()
 
         assertNull(viewModel.selectedRecipe.value)
@@ -85,7 +96,7 @@ class CollectionViewModelTest {
     @Test
     fun `onRecipeRemove with copyId calls removeRecipe`() = runTest(testDispatcher) {
         val repository = FakeRecipeRepository(sampleRecipes)
-        val viewModel = CollectionViewModel(repository, FakeRecipeListRepository())
+        val viewModel = CollectionViewModel(repository, FakeRecipeListRepository(), FakeRecipeVariantRepository())
         advanceUntilIdle()
 
         val recipeWithCopyId = sampleRecipes[2] // has copyId
@@ -101,7 +112,7 @@ class CollectionViewModelTest {
     @Test
     fun `onRecipeRemove without copyId calls removeRecipeUid`() = runTest(testDispatcher) {
         val repository = FakeRecipeRepository(sampleRecipes)
-        val viewModel = CollectionViewModel(repository, FakeRecipeListRepository())
+        val viewModel = CollectionViewModel(repository, FakeRecipeListRepository(), FakeRecipeVariantRepository())
         advanceUntilIdle()
 
         val recipeWithoutCopyId = sampleRecipes[0] // no copyId
@@ -116,7 +127,7 @@ class CollectionViewModelTest {
     @Test
     fun `onRecipeRemove clears selectedRecipe`() = runTest(testDispatcher) {
         val repository = FakeRecipeRepository(sampleRecipes)
-        val viewModel = CollectionViewModel(repository, FakeRecipeListRepository())
+        val viewModel = CollectionViewModel(repository, FakeRecipeListRepository(), FakeRecipeVariantRepository())
         advanceUntilIdle()
 
         viewModel.onRecipeSelected(sampleRecipes[0])
@@ -128,13 +139,13 @@ class CollectionViewModelTest {
 
     @Test
     fun `isCookingMode is initially false`() = runTest(testDispatcher) {
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), FakeRecipeListRepository())
+        val (viewModel, _) = makeViewModel()
         assertFalse(viewModel.isCookingMode.value)
     }
 
     @Test
     fun `onToggleCookingMode enables cooking mode`() = runTest(testDispatcher) {
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), FakeRecipeListRepository())
+        val (viewModel, _) = makeViewModel()
         advanceUntilIdle()
         viewModel.onRecipeSelected(sampleRecipes[0])
 
@@ -145,7 +156,7 @@ class CollectionViewModelTest {
 
     @Test
     fun `onToggleCookingMode disables cooking mode and clears state`() = runTest(testDispatcher) {
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), FakeRecipeListRepository())
+        val (viewModel, _) = makeViewModel()
         advanceUntilIdle()
         viewModel.onRecipeSelected(sampleRecipes[0])
         viewModel.onToggleCookingMode() // enable
@@ -162,10 +173,10 @@ class CollectionViewModelTest {
     @Test
     fun `onToggleCookingMode initializes currentServings from recipe servings string`() = runTest(testDispatcher) {
         val recipeWithServings = Recipe(id = "4", uid = "user-1", title = "Soup", servings = "4 servings")
-        val viewModel =
-            CollectionViewModel(FakeRecipeRepository(listOf(recipeWithServings)), FakeRecipeListRepository())
+        val (viewModel, _) = makeViewModel(recipes = listOf(recipeWithServings))
         advanceUntilIdle()
         viewModel.onRecipeSelected(recipeWithServings)
+        advanceUntilIdle() // allow displayedRecipe combine flow to emit
 
         viewModel.onToggleCookingMode()
 
@@ -174,7 +185,7 @@ class CollectionViewModelTest {
 
     @Test
     fun `onToggleCookingMode clears checkedSteps on activation`() = runTest(testDispatcher) {
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), FakeRecipeListRepository())
+        val (viewModel, _) = makeViewModel()
         advanceUntilIdle()
         viewModel.onRecipeSelected(sampleRecipes[0])
         viewModel.onToggleCookingMode() // enable
@@ -187,7 +198,7 @@ class CollectionViewModelTest {
 
     @Test
     fun `onStepChecked adds step index to checkedSteps`() = runTest(testDispatcher) {
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), FakeRecipeListRepository())
+        val (viewModel, _) = makeViewModel()
         advanceUntilIdle()
 
         viewModel.onStepChecked(2)
@@ -198,7 +209,7 @@ class CollectionViewModelTest {
 
     @Test
     fun `onServingsChanged updates currentServings`() = runTest(testDispatcher) {
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), FakeRecipeListRepository())
+        val (viewModel, _) = makeViewModel()
         advanceUntilIdle()
 
         viewModel.onServingsChanged(6)
@@ -208,7 +219,7 @@ class CollectionViewModelTest {
 
     @Test
     fun `clearSelectedRecipe clears selectedRecipe without resetting cooking mode`() = runTest(testDispatcher) {
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), FakeRecipeListRepository())
+        val (viewModel, _) = makeViewModel()
         advanceUntilIdle()
         viewModel.onRecipeSelected(sampleRecipes[0])
         viewModel.onToggleCookingMode()
@@ -223,7 +234,7 @@ class CollectionViewModelTest {
 
     @Test
     fun `onRecipeSelected resets cooking mode state when selecting a different recipe`() = runTest(testDispatcher) {
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), FakeRecipeListRepository())
+        val (viewModel, _) = makeViewModel()
         advanceUntilIdle()
         viewModel.onRecipeSelected(sampleRecipes[0])
         viewModel.onToggleCookingMode()
@@ -239,7 +250,7 @@ class CollectionViewModelTest {
 
     @Test
     fun `onStepUnchecked removes step index from checkedSteps`() = runTest(testDispatcher) {
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), FakeRecipeListRepository())
+        val (viewModel, _) = makeViewModel()
         advanceUntilIdle()
 
         viewModel.onStepChecked(2)
@@ -252,7 +263,7 @@ class CollectionViewModelTest {
 
     @Test
     fun `onServingsChanged caps at MAX_SERVINGS`() = runTest(testDispatcher) {
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), FakeRecipeListRepository())
+        val (viewModel, _) = makeViewModel()
 
         viewModel.onServingsChanged(CollectionViewModel.MAX_SERVINGS + 10)
 
@@ -261,7 +272,7 @@ class CollectionViewModelTest {
 
     @Test
     fun `onServingsChanged floors at 1`() = runTest(testDispatcher) {
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), FakeRecipeListRepository())
+        val (viewModel, _) = makeViewModel()
 
         viewModel.onServingsChanged(0)
 
@@ -270,7 +281,7 @@ class CollectionViewModelTest {
 
     @Test
     fun `onTabChanged updates showIngredients`() = runTest(testDispatcher) {
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), FakeRecipeListRepository())
+        val (viewModel, _) = makeViewModel()
 
         viewModel.onTabChanged(false)
         assertFalse(viewModel.showIngredients.value)
@@ -281,7 +292,7 @@ class CollectionViewModelTest {
 
     @Test
     fun `showIngredients resets to true when a different recipe is selected`() = runTest(testDispatcher) {
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), FakeRecipeListRepository())
+        val (viewModel, _) = makeViewModel()
         advanceUntilIdle()
         viewModel.onRecipeSelected(sampleRecipes[0])
         viewModel.onTabChanged(false)
@@ -293,7 +304,7 @@ class CollectionViewModelTest {
 
     @Test
     fun `showIngredients persists when re-selecting the same recipe`() = runTest(testDispatcher) {
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), FakeRecipeListRepository())
+        val (viewModel, _) = makeViewModel()
         advanceUntilIdle()
         viewModel.onRecipeSelected(sampleRecipes[0])
         viewModel.onToggleCookingMode()
@@ -307,7 +318,7 @@ class CollectionViewModelTest {
 
     @Test
     fun `onRecipeSelected preserves cooking mode state when re-selecting the same recipe`() = runTest(testDispatcher) {
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), FakeRecipeListRepository())
+        val (viewModel, _) = makeViewModel()
         advanceUntilIdle()
         viewModel.onRecipeSelected(sampleRecipes[0])
         viewModel.onToggleCookingMode()
@@ -327,7 +338,7 @@ class CollectionViewModelTest {
     fun `setCurrentUser loads lists for uid`() = runTest(testDispatcher) {
         val sampleLists = listOf(RecipeList(id = "list-1", name = "Work week", recipeIds = listOf("1")))
         val listRepo = FakeRecipeListRepository(sampleLists)
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), listRepo)
+        val (viewModel, _) = makeViewModel(listRepo = listRepo)
 
         viewModel.setCurrentUser("user-1")
         advanceUntilIdle()
@@ -340,7 +351,7 @@ class CollectionViewModelTest {
     fun `setCurrentUser with null uid clears lists`() = runTest(testDispatcher) {
         val sampleLists = listOf(RecipeList(id = "list-1", name = "Work week"))
         val listRepo = FakeRecipeListRepository(sampleLists)
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), listRepo)
+        val (viewModel, _) = makeViewModel(listRepo = listRepo)
         viewModel.setCurrentUser("user-1")
         advanceUntilIdle()
 
@@ -352,7 +363,7 @@ class CollectionViewModelTest {
     @Test
     fun `onCreateList adds list to state immediately (optimistic)`() = runTest(testDispatcher) {
         val listRepo = FakeRecipeListRepository()
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), listRepo)
+        val (viewModel, _) = makeViewModel(listRepo = listRepo)
         viewModel.setCurrentUser("user-1")
         advanceUntilIdle()
 
@@ -369,7 +380,7 @@ class CollectionViewModelTest {
             RecipeList(id = "list-2", name = "Festive")
         )
         val listRepo = FakeRecipeListRepository(sampleLists)
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), listRepo)
+        val (viewModel, _) = makeViewModel(listRepo = listRepo)
         viewModel.setCurrentUser("user-1")
         advanceUntilIdle()
 
@@ -384,7 +395,7 @@ class CollectionViewModelTest {
     fun `onDeleteList clears expandedListId if it matches`() = runTest(testDispatcher) {
         val sampleLists = listOf(RecipeList(id = "list-1", name = "Work week"))
         val listRepo = FakeRecipeListRepository(sampleLists)
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), listRepo)
+        val (viewModel, _) = makeViewModel(listRepo = listRepo)
         viewModel.setCurrentUser("user-1")
         advanceUntilIdle()
         viewModel.onExpandList("list-1")
@@ -399,7 +410,7 @@ class CollectionViewModelTest {
     fun `onAddRecipeToList updates local state`() = runTest(testDispatcher) {
         val sampleLists = listOf(RecipeList(id = "list-1", name = "Work week", recipeIds = emptyList()))
         val listRepo = FakeRecipeListRepository(sampleLists)
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), listRepo)
+        val (viewModel, _) = makeViewModel(listRepo = listRepo)
         viewModel.setCurrentUser("user-1")
         advanceUntilIdle()
 
@@ -413,7 +424,7 @@ class CollectionViewModelTest {
     fun `onAddRecipeToList does not duplicate recipe`() = runTest(testDispatcher) {
         val sampleLists = listOf(RecipeList(id = "list-1", name = "Work week", recipeIds = listOf("recipe-1")))
         val listRepo = FakeRecipeListRepository(sampleLists)
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), listRepo)
+        val (viewModel, _) = makeViewModel(listRepo = listRepo)
         viewModel.setCurrentUser("user-1")
         advanceUntilIdle()
 
@@ -427,7 +438,7 @@ class CollectionViewModelTest {
         val sampleLists =
             listOf(RecipeList(id = "list-1", name = "Work week", recipeIds = listOf("recipe-1", "recipe-2")))
         val listRepo = FakeRecipeListRepository(sampleLists)
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), listRepo)
+        val (viewModel, _) = makeViewModel(listRepo = listRepo)
         viewModel.setCurrentUser("user-1")
         advanceUntilIdle()
 
@@ -440,7 +451,7 @@ class CollectionViewModelTest {
 
     @Test
     fun `onExpandList toggles expandedListId`() = runTest(testDispatcher) {
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), FakeRecipeListRepository())
+        val (viewModel, _) = makeViewModel()
 
         viewModel.onExpandList("list-1")
         assertEquals("list-1", viewModel.expandedListId.value)
@@ -451,12 +462,258 @@ class CollectionViewModelTest {
 
     @Test
     fun `onExpandList switches to a different list`() = runTest(testDispatcher) {
-        val viewModel = CollectionViewModel(FakeRecipeRepository(sampleRecipes), FakeRecipeListRepository())
+        val (viewModel, _) = makeViewModel()
 
         viewModel.onExpandList("list-1")
         viewModel.onExpandList("list-2")
 
         assertEquals("list-2", viewModel.expandedListId.value)
+    }
+
+    // --- Variant tests ---
+
+    @Test
+    fun `variants state updates after recipe selected`() = runTest(testDispatcher) {
+        val v1 = RecipeVariant(id = "v1", label = "Vegan")
+        val (viewModel, _) = makeViewModel(variants = mapOf("1" to listOf(v1)))
+
+        viewModel.onRecipeSelected(sampleRecipes[0])
+        advanceUntilIdle()
+
+        assertEquals(1, viewModel.variants.value.size)
+        assertEquals("Vegan", viewModel.variants.value[0].label)
+    }
+
+    @Test
+    fun `pinned variant auto-selected when owner opens recipe`() = runTest(testDispatcher) {
+        val pinned = RecipeVariant(id = "v1", label = "Vegan", isPinned = true)
+        val (viewModel, _) = makeViewModel(variants = mapOf("1" to listOf(pinned)))
+
+        viewModel.setCurrentUser("user-1") // sampleRecipes[0].uid is "user-1"
+        viewModel.onRecipeSelected(sampleRecipes[0])
+        advanceUntilIdle()
+
+        assertEquals("v1", viewModel.selectedVariantId.value)
+    }
+
+    @Test
+    fun `non-owner does not auto-select pinned variant`() = runTest(testDispatcher) {
+        val pinned = RecipeVariant(id = "v1", label = "Vegan", isPinned = true)
+        val (viewModel, _) = makeViewModel(variants = mapOf("1" to listOf(pinned)))
+
+        viewModel.setCurrentUser("other-user")
+        viewModel.onRecipeSelected(sampleRecipes[0])
+        advanceUntilIdle()
+
+        assertNull(viewModel.selectedVariantId.value)
+    }
+
+    @Test
+    fun `onVariantSelected updates selectedVariantId`() = runTest(testDispatcher) {
+        val v1 = RecipeVariant(id = "v1", label = "Vegan")
+        val (viewModel, _) = makeViewModel(variants = mapOf("1" to listOf(v1)))
+        viewModel.onRecipeSelected(sampleRecipes[0])
+        advanceUntilIdle()
+
+        viewModel.onVariantSelected("v1")
+
+        assertEquals("v1", viewModel.selectedVariantId.value)
+    }
+
+    @Test
+    fun `onVariantSelected null falls back to canonical`() = runTest(testDispatcher) {
+        val v1 = RecipeVariant(id = "v1", label = "Vegan")
+        val (viewModel, _) = makeViewModel(variants = mapOf("1" to listOf(v1)))
+        viewModel.onRecipeSelected(sampleRecipes[0])
+        advanceUntilIdle()
+        viewModel.onVariantSelected("v1")
+
+        viewModel.onVariantSelected(null)
+
+        assertNull(viewModel.selectedVariantId.value)
+    }
+
+    @Test
+    fun `displayedRecipe returns canonical recipe when no variant selected`() = runTest(testDispatcher) {
+        val (viewModel, _) = makeViewModel()
+        viewModel.onRecipeSelected(sampleRecipes[0])
+        advanceUntilIdle()
+
+        assertEquals("Pasta Carbonara", viewModel.displayedRecipe.value?.title)
+        assertEquals(sampleRecipes[0].id, viewModel.displayedRecipe.value?.id)
+    }
+
+    @Test
+    fun `displayedRecipe merges variant fields and preserves parent imageUrl`() = runTest(testDispatcher) {
+        val parentWithImage = sampleRecipes[0].copy(imageUrl = "https://example.com/img.jpg")
+        val v1 = RecipeVariant(id = "v1", label = "Vegan", title = "Vegan Pasta", summary = "Dairy-free")
+        val (viewModel, _) = makeViewModel(
+            recipes = listOf(parentWithImage) + sampleRecipes.drop(1),
+            variants = mapOf("1" to listOf(v1))
+        )
+        viewModel.onRecipeSelected(parentWithImage)
+        advanceUntilIdle()
+        viewModel.onVariantSelected("v1")
+        advanceUntilIdle()
+
+        val displayed = viewModel.displayedRecipe.value
+        assertEquals("Vegan Pasta", displayed?.title)
+        assertEquals("Dairy-free", displayed?.summary)
+        assertEquals("https://example.com/img.jpg", displayed?.imageUrl)
+        assertEquals("1", displayed?.id)
+    }
+
+    @Test
+    fun `onPinVariant sets isPinned on new variant and clears previous`() = runTest(testDispatcher) {
+        val v1 = RecipeVariant(id = "v1", label = "A", isPinned = true)
+        val v2 = RecipeVariant(id = "v2", label = "B", isPinned = false)
+        val (viewModel, variantRepo) = makeViewModel(variants = mapOf("1" to listOf(v1, v2)))
+        viewModel.onRecipeSelected(sampleRecipes[0])
+        advanceUntilIdle()
+
+        viewModel.onPinVariant("v2")
+
+        assertTrue(viewModel.variants.value.first { it.id == "v2" }.isPinned)
+        assertFalse(viewModel.variants.value.first { it.id == "v1" }.isPinned)
+        assertTrue(variantRepo.pinnedUpdates.contains(Triple("1", "v2", true)))
+        assertTrue(variantRepo.pinnedUpdates.contains(Triple("1", "v1", false)))
+    }
+
+    @Test
+    fun `onPinVariant null unpins all variants`() = runTest(testDispatcher) {
+        val v1 = RecipeVariant(id = "v1", label = "A", isPinned = true)
+        val (viewModel, variantRepo) = makeViewModel(variants = mapOf("1" to listOf(v1)))
+        viewModel.onRecipeSelected(sampleRecipes[0])
+        advanceUntilIdle()
+
+        viewModel.onPinVariant(null)
+
+        assertFalse(viewModel.variants.value.first { it.id == "v1" }.isPinned)
+        assertTrue(variantRepo.pinnedUpdates.contains(Triple("1", "v1", false)))
+    }
+
+    @Test
+    fun `onDeleteVariant removes variant from state`() = runTest(testDispatcher) {
+        val v1 = RecipeVariant(id = "v1", label = "A")
+        val v2 = RecipeVariant(id = "v2", label = "B")
+        val (viewModel, variantRepo) = makeViewModel(variants = mapOf("1" to listOf(v1, v2)))
+        viewModel.onRecipeSelected(sampleRecipes[0])
+        advanceUntilIdle()
+
+        viewModel.onDeleteVariant("v1")
+
+        assertEquals(1, viewModel.variants.value.size)
+        assertEquals("v2", viewModel.variants.value[0].id)
+        assertTrue(variantRepo.deletedVariants.contains("v1"))
+    }
+
+    @Test
+    fun `onDeleteVariant of selected variant clears selectedVariantId`() = runTest(testDispatcher) {
+        val v1 = RecipeVariant(id = "v1", label = "A")
+        val (viewModel, _) = makeViewModel(variants = mapOf("1" to listOf(v1)))
+        viewModel.onRecipeSelected(sampleRecipes[0])
+        advanceUntilIdle()
+        viewModel.onVariantSelected("v1")
+
+        viewModel.onDeleteVariant("v1")
+
+        assertNull(viewModel.selectedVariantId.value)
+    }
+
+    @Test
+    fun `onDeleteVariant of pinned variant does not crash`() = runTest(testDispatcher) {
+        val v1 = RecipeVariant(id = "v1", label = "A", isPinned = true)
+        val (viewModel, _) = makeViewModel(variants = mapOf("1" to listOf(v1)))
+        viewModel.onRecipeSelected(sampleRecipes[0])
+        advanceUntilIdle()
+
+        viewModel.onDeleteVariant("v1")
+
+        assertTrue(viewModel.variants.value.isEmpty())
+    }
+
+    @Test
+    fun `onSaveVariant appends to variants and selects new variant`() = runTest(testDispatcher) {
+        val existingVariant = RecipeVariant(id = "v1", label = "A")
+        val variantRepo = FakeRecipeVariantRepository(
+            initialData = mapOf("1" to listOf(existingVariant)),
+            autoAssignIds = true
+        )
+        val viewModel =
+            CollectionViewModel(FakeRecipeRepository(sampleRecipes), FakeRecipeListRepository(), variantRepo)
+        viewModel.onRecipeSelected(sampleRecipes[0])
+        advanceUntilIdle()
+
+        viewModel.onSaveVariant("New Variant", sampleRecipes[0])
+        advanceUntilIdle()
+
+        assertEquals(2, viewModel.variants.value.size)
+        assertFalse(viewModel.isEditingVariant.value)
+        val saved = viewModel.variants.value.first { it.label == "New Variant" }
+        assertEquals(viewModel.selectedVariantId.value, saved.id)
+    }
+
+    @Test
+    fun `clearSelectedRecipe resets variants and selectedVariantId`() = runTest(testDispatcher) {
+        val v1 = RecipeVariant(id = "v1", label = "A")
+        val (viewModel, _) = makeViewModel(variants = mapOf("1" to listOf(v1)))
+        viewModel.onRecipeSelected(sampleRecipes[0])
+        advanceUntilIdle()
+        viewModel.onVariantSelected("v1")
+
+        viewModel.clearSelectedRecipe()
+
+        assertTrue(viewModel.variants.value.isEmpty())
+        assertNull(viewModel.selectedVariantId.value)
+        assertFalse(viewModel.isEditingVariant.value)
+    }
+
+    @Test
+    fun `onStartCreateVariant sets isEditingVariant true`() = runTest(testDispatcher) {
+        val (viewModel, _) = makeViewModel()
+
+        viewModel.onStartCreateVariant()
+
+        assertTrue(viewModel.isEditingVariant.value)
+    }
+
+    @Test
+    fun `onCancelEditVariant clears isEditingVariant`() = runTest(testDispatcher) {
+        val (viewModel, _) = makeViewModel()
+        viewModel.onStartCreateVariant()
+
+        viewModel.onCancelEditVariant()
+
+        assertFalse(viewModel.isEditingVariant.value)
+    }
+}
+
+private class FakeRecipeVariantRepository(
+    initialData: Map<String, List<RecipeVariant>> = emptyMap(),
+    private val autoAssignIds: Boolean = false
+) : RecipeVariantRepository {
+    private val data: MutableMap<String, MutableList<RecipeVariant>> =
+        initialData.mapValues { it.value.toMutableList() }.toMutableMap()
+    val pinnedUpdates = mutableListOf<Triple<String, String, Boolean>>() // recipeId, variantId, isPinned
+    val deletedVariants = mutableListOf<String>()
+    private var idCounter = 100
+
+    override suspend fun loadVariantsForRecipe(recipeId: String): List<RecipeVariant> =
+        data[recipeId]?.toList() ?: emptyList()
+
+    override fun saveVariant(recipeId: String, variant: RecipeVariant) {
+        val stored = if (autoAssignIds) variant.copy(id = "generated-${idCounter++}") else variant
+        data.getOrPut(recipeId) { mutableListOf() }.add(stored)
+    }
+
+    override fun updateVariantIsPinned(recipeId: String, variantId: String, isPinned: Boolean) {
+        pinnedUpdates.add(Triple(recipeId, variantId, isPinned))
+        data[recipeId]?.replaceAll { if (it.id == variantId) it.copy(isPinned = isPinned) else it }
+    }
+
+    override fun deleteVariant(recipeId: String, variantId: String) {
+        deletedVariants.add(variantId)
+        data[recipeId]?.removeIf { it.id == variantId }
     }
 }
 

--- a/vertexai/app/src/test/kotlin/com/formulae/chef/feature/model/RecipeVariantTest.kt
+++ b/vertexai/app/src/test/kotlin/com/formulae/chef/feature/model/RecipeVariantTest.kt
@@ -3,6 +3,7 @@ package com.formulae.chef.feature.model
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class RecipeVariantTest {
@@ -29,7 +30,7 @@ class RecipeVariantTest {
     @Test
     fun `isPinned can be set to true`() {
         val variant = RecipeVariant(isPinned = true)
-        assert(variant.isPinned)
+        assertTrue(variant.isPinned)
     }
 
     @Test

--- a/vertexai/app/src/test/kotlin/com/formulae/chef/feature/model/RecipeVariantTest.kt
+++ b/vertexai/app/src/test/kotlin/com/formulae/chef/feature/model/RecipeVariantTest.kt
@@ -1,0 +1,65 @@
+package com.formulae.chef.feature.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class RecipeVariantTest {
+
+    @Test
+    fun `default construction has expected defaults`() {
+        val variant = RecipeVariant()
+        assertNull(variant.id)
+        assertEquals("", variant.label)
+        assertEquals("", variant.createdAt)
+        assertFalse(variant.isPinned)
+        assertEquals("", variant.title)
+        assertEquals("", variant.summary)
+        assertEquals("", variant.servings)
+        assertNull(variant.prepTime)
+        assertNull(variant.cookingTime)
+        assertEquals(emptyList<Nutrient>(), variant.nutrientsPerServing)
+        assertEquals(emptyList<Ingredient>(), variant.ingredients)
+        assertEquals(Difficulty.EASY, variant.difficulty)
+        assertEquals(emptyList<String>(), variant.instructions)
+        assertNull(variant.tipsAndTricks)
+    }
+
+    @Test
+    fun `isPinned can be set to true`() {
+        val variant = RecipeVariant(isPinned = true)
+        assert(variant.isPinned)
+    }
+
+    @Test
+    fun `copy preserves all fields`() {
+        val original = RecipeVariant(
+            id = "v1",
+            label = "Vegetarian",
+            createdAt = "2026-01-01T00:00:00Z",
+            isPinned = true,
+            title = "Veggie Stew",
+            summary = "A hearty stew",
+            servings = "4 servings",
+            prepTime = "10 minutes",
+            cookingTime = "30 minutes",
+            ingredients = listOf(Ingredient(name = "Carrot", quantity = "2", unit = "pcs")),
+            instructions = listOf("Chop veggies", "Simmer"),
+            difficulty = Difficulty.MEDIUM,
+            tipsAndTricks = "Use fresh herbs"
+        )
+        val copied = original.copy(label = "Updated")
+        assertEquals("v1", copied.id)
+        assertEquals("Updated", copied.label)
+        assertEquals(true, copied.isPinned)
+        assertEquals(Difficulty.MEDIUM, copied.difficulty)
+        assertEquals("Veggie Stew", copied.title)
+    }
+
+    @Test
+    fun `difficulty defaults to EASY`() {
+        val variant = RecipeVariant()
+        assertEquals(Difficulty.EASY, variant.difficulty)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `RecipeVariant` model stored at `recipe_variants/{recipeId}/{variantId}/` in Firebase (separate node, no changes to `recipes/`)
- Variant picker dropdown appears on the recipe detail screen; only the owner sees star (pin) and + (create) controls
- Pinned variant auto-selects when the owner opens the recipe; other users always see the canonical recipe
- "Create variant" pre-populates the edit form from whatever is currently displayed (canonical or another variant)
- `displayedRecipe` StateFlow merges variant fields with the parent recipe's `imageUrl`, `uid`, etc.
- Delete variant supported; deleting the pinned variant clears the pin and reverts to canonical

## Test plan

- [x] `ktlintCheck` — pass
- [x] `assembleDebug` — pass
- [x] `testDebugUnitTest` — 163+ tests pass (14 new variant scenarios + updated existing tests)
- [ ] Manual E2E:
  1. Open a recipe you own — dropdown shows "Default ★"
  2. Tap "+" — edit form opens blank label, fields pre-populated from recipe; save as "Vegetarian version"
  3. Dropdown now shows "Default ★" and "Vegetarian version ☆"
  4. Switch to "Vegetarian version" — detail shows edited content, same image as parent
  5. With variant selected, tap "+" — edit form pre-populated from VARIANT data
  6. Tap star on "Vegetarian version" — it becomes ★; Default shows ☆
  7. Navigate back then re-open recipe — opens directly to "Vegetarian version" (pinned)
  8. Sign in as another user — no stars, no + button, always shows canonical
  9. Back as owner: delete "Vegetarian version" — pin clears, remaining variants intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)