### PR TITLE
#23: Fix Instructions tab not working in chat recipe detail view

### DIFF
--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/chat/ui/ChatScreen.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/chat/ui/ChatScreen.kt
@@ -91,10 +91,14 @@ internal fun ChatRoute(
         onDispose { chatViewModel.onNavigateAway() }
     }
 
+    var showIngredients by rememberSaveable(selectedRecipe?.id) { mutableStateOf(true) }
+
     if (selectedRecipe != null) {
         DetailRoute(
             recipe = selectedRecipe!!,
-            onBack = { chatViewModel.clearSelectedRecipe() }
+            onBack = { chatViewModel.clearSelectedRecipe() },
+            showIngredients = showIngredients,
+            onTabChanged = { showIngredients = it }
         )
     } else {
         ChatContent(chatViewModel)


### PR DESCRIPTION
## Summary

- `ChatRoute` was calling `DetailRoute` without `showIngredients` state or `onTabChanged` callback, so both defaulted to no-ops
- Added local `rememberSaveable` state (keyed on `recipe.id`) in `ChatRoute` and wired it to `DetailRoute`
- Tab state resets to Ingredients whenever a different recipe is opened

## Test plan

- [ ] Open Chat, tap a recipe card to open the detail view
- [ ] Tap **Instructions** tab — content switches to instructions
- [ ] Tap **Ingredients** tab — content switches back to ingredients
- [ ] Navigate back to chat, open a different recipe — tab resets to Ingredients

Closes #23