### PR TITLE
CHE-16: Display tips and tricks section in recipe detail view

### DIFF
--- a/vertexai/app/src/main/kotlin/com/formulae/chef/GenerativeAiViewModelFactory.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/GenerativeAiViewModelFactory.kt
@@ -57,7 +57,7 @@ private const val DERIVE_RECIPE_JSON_SYSTEM_INSTRUCTIONS =
       "ingredients": [{"name": "string", "quantity": "numeric string only, e.g. '500', '2', '0.5', '1/2' — never include the unit here", "unit": "string"}],
       "difficulty": "EASY | MEDIUM | HARD",
       "instructions": ["string, one step per element"],
-      "tipsAndTricks": "string",
+      "tipsAndTricks": "string, formatted as '- ' prefixed bullet lines, one tip per line starting with '- '",
       "tags": ["string"]
     }
   ]

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/CollectionViewModel.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/CollectionViewModel.kt
@@ -321,3 +321,25 @@ class CollectionViewModel(
         const val MAX_SERVINGS = 30
     }
 }
+
+internal fun parseTips(tipsAndTricks: String): List<String> {
+    val lines = tipsAndTricks.lines()
+    val tips = mutableListOf<String>()
+    val current = StringBuilder()
+    for (line in lines) {
+        when {
+            line.startsWith("- ") -> {
+                if (current.isNotEmpty()) tips.add(current.toString().trim())
+                current.clear()
+                current.append(line.removePrefix("- ").trim())
+            }
+            line.isNotBlank() -> {
+                if (current.isNotEmpty()) current.append(" ")
+                current.append(line.trim())
+            }
+        }
+    }
+    if (current.isNotEmpty()) tips.add(current.toString().trim())
+    if (tips.isEmpty() && tipsAndTricks.isNotBlank()) tips.add(tipsAndTricks.trim())
+    return tips
+}

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/DetailScreen.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/DetailScreen.kt
@@ -297,6 +297,10 @@ private fun CreateDetailScreen(
             )
         }
 
+        recipe.tipsAndTricks?.takeIf { it.isNotBlank() }?.let { tips ->
+            TipsSection(tipsAndTricks = tips)
+        }
+
         // Share Button
         Row(
             modifier = Modifier
@@ -388,4 +392,41 @@ fun PreviewCreateDetailScreen() {
         onStepUnchecked = {},
         onServingsChanged = {}
     )
+}
+
+internal fun parseTips(tipsAndTricks: String): List<String> {
+    val lines = tipsAndTricks.lines()
+    val tips = mutableListOf<String>()
+    val current = StringBuilder()
+    for (line in lines) {
+        when {
+            line.startsWith("- ") -> {
+                if (current.isNotEmpty()) tips.add(current.toString().trim())
+                current.clear()
+                current.append(line.removePrefix("- ").trim())
+            }
+            line.isNotBlank() -> {
+                if (current.isNotEmpty()) current.append(" ")
+                current.append(line.trim())
+            }
+        }
+    }
+    if (current.isNotEmpty()) tips.add(current.toString().trim())
+    if (tips.isEmpty() && tipsAndTricks.isNotBlank()) tips.add(tipsAndTricks.trim())
+    return tips
+}
+
+@Composable
+private fun TipsSection(tipsAndTricks: String) {
+    val tips = parseTips(tipsAndTricks)
+    Text(text = "Tips", style = MaterialTheme.typography.headlineSmall)
+    Spacer(modifier = Modifier.height(8.dp))
+    tips.forEach { tip ->
+        Text(
+            text = "• $tip",
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(bottom = 4.dp)
+        )
+    }
+    Spacer(modifier = Modifier.height(8.dp))
 }

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/DetailScreen.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/DetailScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 import com.formulae.chef.BuildConfig
+import com.formulae.chef.feature.collection.parseTips
 import com.formulae.chef.feature.model.Difficulty
 import com.formulae.chef.feature.model.Ingredient
 import com.formulae.chef.feature.model.Nutrient
@@ -392,28 +393,6 @@ fun PreviewCreateDetailScreen() {
         onStepUnchecked = {},
         onServingsChanged = {}
     )
-}
-
-internal fun parseTips(tipsAndTricks: String): List<String> {
-    val lines = tipsAndTricks.lines()
-    val tips = mutableListOf<String>()
-    val current = StringBuilder()
-    for (line in lines) {
-        when {
-            line.startsWith("- ") -> {
-                if (current.isNotEmpty()) tips.add(current.toString().trim())
-                current.clear()
-                current.append(line.removePrefix("- ").trim())
-            }
-            line.isNotBlank() -> {
-                if (current.isNotEmpty()) current.append(" ")
-                current.append(line.trim())
-            }
-        }
-    }
-    if (current.isNotEmpty()) tips.add(current.toString().trim())
-    if (tips.isEmpty() && tipsAndTricks.isNotBlank()) tips.add(tipsAndTricks.trim())
-    return tips
 }
 
 @Composable

--- a/vertexai/app/src/test/kotlin/com/formulae/chef/feature/collection/ui/ParseTipsTest.kt
+++ b/vertexai/app/src/test/kotlin/com/formulae/chef/feature/collection/ui/ParseTipsTest.kt
@@ -1,0 +1,77 @@
+package com.formulae.chef.feature.collection.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ParseTipsTest {
+
+    @Test
+    fun `bullet lines are split into separate tips`() {
+        val input = "- Store in airtight container\n- Reheat gently on low heat\n- Substitute chicken for lamb"
+
+        val result = parseTips(input)
+
+        assertEquals(3, result.size)
+        assertEquals("Store in airtight container", result[0])
+        assertEquals("Reheat gently on low heat", result[1])
+        assertEquals("Substitute chicken for lamb", result[2])
+    }
+
+    @Test
+    fun `multi-line tip is joined into one entry`() {
+        val input = "- Store leftovers in an airtight container\n  in the fridge for up to 3 days\n- Reheat gently"
+
+        val result = parseTips(input)
+
+        assertEquals(2, result.size)
+        assertEquals("Store leftovers in an airtight container in the fridge for up to 3 days", result[0])
+        assertEquals("Reheat gently", result[1])
+    }
+
+    @Test
+    fun `fallback - no bullets renders whole string as single tip`() {
+        val input = "For milder flavor reduce cayenne pepper. Use zucchini instead of listed vegetables."
+
+        val result = parseTips(input)
+
+        assertEquals(1, result.size)
+        assertEquals(input.trim(), result[0])
+    }
+
+    @Test
+    fun `empty string returns empty list`() {
+        val result = parseTips("")
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `blank-only string returns empty list`() {
+        val result = parseTips("   \n  \n ")
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `single bullet tip is parsed correctly`() {
+        val input = "- Use room temperature butter for best results"
+
+        val result = parseTips(input)
+
+        assertEquals(1, result.size)
+        assertEquals("Use room temperature butter for best results", result[0])
+    }
+
+    @Test
+    fun `blank lines between bullets are ignored`() {
+        val input = "- First tip\n\n- Second tip\n\n- Third tip"
+
+        val result = parseTips(input)
+
+        assertEquals(3, result.size)
+        assertEquals("First tip", result[0])
+        assertEquals("Second tip", result[1])
+        assertEquals("Third tip", result[2])
+    }
+}

--- a/vertexai/app/src/test/kotlin/com/formulae/chef/feature/collection/ui/ParseTipsTest.kt
+++ b/vertexai/app/src/test/kotlin/com/formulae/chef/feature/collection/ui/ParseTipsTest.kt
@@ -1,5 +1,6 @@
 package com.formulae.chef.feature.collection.ui
 
+import com.formulae.chef.feature.collection.parseTips
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -73,5 +74,16 @@ class ParseTipsTest {
         assertEquals("First tip", result[0])
         assertEquals("Second tip", result[1])
         assertEquals("Third tip", result[2])
+    }
+
+    @Test
+    fun `dash without space does not start a new bullet`() {
+        val input = "-tip without space\n-another without space"
+
+        val result = parseTips(input)
+
+        // Both lines accumulate as one entry (no '- ' prefix to split on)
+        assertEquals(1, result.size)
+        assertEquals("-tip without space -another without space", result[0])
     }
 }


### PR DESCRIPTION
## Summary

- Render `tipsAndTricks` as a bullet list just above the "Share Recipe" button in `DetailScreen`
- Add `parseTips()` helper that splits on `- ` prefixed lines, joins continuation lines into the same bullet, and falls back to a single bullet for existing recipes without the format
- Update `DERIVE_RECIPE_JSON_SYSTEM_INSTRUCTIONS` to tell the extraction model to format `tipsAndTricks` using `- ` prefixed bullets (matching the chat system prompt format)
- Add `ParseTipsTest` with 7 unit tests covering: bullet splitting, multi-line tips, no-bullet fallback, empty/blank input, single bullet, and blank lines between bullets

## Test plan

- [ ] Open a saved recipe with `tipsAndTricks` content → "Tips" section appears above "Share Recipe" with `•` bullets
- [ ] Open a recipe without `tipsAndTricks` → no "Tips" section appears
- [ ] Generate a new recipe via chat → save → open detail view → tips render as bullets
- [ ] `ktlintCheck` passes
- [ ] `assembleDebug` passes
- [ ] `testDebugUnitTest` passes (25 tests including 7 new `ParseTipsTest`)

Closes CHE-16