### PR TITLE
CHE-17: Main screen dashboard backend support

### DIFF
--- a/vertexai/app/src/main/kotlin/com/formulae/chef/AppNavigation.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/AppNavigation.kt
@@ -2,11 +2,15 @@ package com.formulae.chef
 
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import com.formulae.chef.feature.chat.ui.ChatRoute
 import com.formulae.chef.feature.collection.ui.CollectionRoute
+import com.formulae.chef.feature.collection.ui.RecipeSource
+import com.formulae.chef.feature.home.HomeScreenViewModel
 import com.formulae.chef.feature.useraccount.ui.SignInRoute
 import com.formulae.chef.services.authentication.UserSessionService
 import com.formulae.chef.services.persistence.RecipeListRepository
@@ -24,21 +28,40 @@ fun AppNavigation(
 
     NavHost(navController = navController, startDestination = "home") {
         composable("home") {
+            val homeViewModel: HomeScreenViewModel = viewModel(
+                factory = HomeScreenViewModelFactory(recipeRepository)
+            )
             HomeScreen(
+                viewModel = homeViewModel,
                 userSessionService = userSessionService,
                 onNavigateToChat = { navController.navigate("chat") },
                 onNavigateToCollection = { navController.navigate("collection") },
+                onNavigateToCommunity = {
+                    navController.navigate("collection?tab=${RecipeSource.ALL_RECIPES.name}")
+                },
                 onSignOut = {
-                    userSessionService.signOut(); navController.navigate("signIn") {
+                    userSessionService.signOut()
+                    navController.navigate("signIn") {
                         popUpTo("home") { inclusive = true }
                     }
                 }
             )
         }
         composable("chat") {
-            ChatRoute() // Your existing ChatRoute
+            ChatRoute()
         }
-        composable("collection") {
+        composable(
+            route = "collection?tab={tab}",
+            arguments = listOf(
+                navArgument("tab") {
+                    type = NavType.StringType
+                    defaultValue = RecipeSource.USER_FAVOURITES.name
+                }
+            )
+        ) { backStackEntry ->
+            val tab = RecipeSource.valueOf(
+                backStackEntry.arguments?.getString("tab") ?: RecipeSource.USER_FAVOURITES.name
+            )
             CollectionRoute(
                 repository = recipeRepository,
                 listRepository = recipeListRepository,
@@ -50,7 +73,8 @@ fun AppNavigation(
                     )
                 ),
                 navController = navController,
-                userSessionService = userSessionService
+                userSessionService = userSessionService,
+                initialRecipeSource = tab
             )
         }
         composable("signIn") {

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/HomeScreen.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/HomeScreen.kt
@@ -2,37 +2,52 @@ package com.formulae.chef
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Chat
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.rememberAsyncImagePainter
 import com.formulae.chef.feature.chat.OverlayChatViewModel
 import com.formulae.chef.feature.chat.ui.ChefOverlay
+import com.formulae.chef.feature.collection.ui.DetailRoute
+import com.formulae.chef.feature.collection.ui.RecipeItem
+import com.formulae.chef.feature.home.HomeScreenViewModel
 import com.formulae.chef.services.authentication.UserSessionService
 import com.google.firebase.auth.UserInfo
 
 @Composable
 fun HomeScreen(
+    viewModel: HomeScreenViewModel,
     userSessionService: UserSessionService,
     onNavigateToChat: () -> Unit = {},
     onNavigateToCollection: () -> Unit = {},
+    onNavigateToCommunity: () -> Unit = {},
     onSignOut: () -> Unit = {}
 ) {
     var isLoading by remember { mutableStateOf(true) }
@@ -49,30 +64,54 @@ fun HomeScreen(
         }
     }
 
+    LaunchedEffect(currentUser) {
+        viewModel.setCurrentUser(currentUser?.uid)
+    }
+
+    val selectedRecipe by viewModel.selectedRecipe.collectAsState()
+    var showIngredients by rememberSaveable(selectedRecipe?.id) { mutableStateOf(true) }
+
     if (isLoading) {
-        CircularProgressIndicator() // Show loader while waiting for user state
+        CircularProgressIndicator()
     } else {
         if (!userSessionService.anonymousSession && currentUser == null) {
             onSignOut()
         }
-        HomeScreenContent(
-            onNavigateToChat,
-            onNavigateToCollection,
-            onSignOut,
-            !userSessionService.anonymousSession && currentUser != null
-        )
+        if (selectedRecipe != null) {
+            DetailRoute(
+                recipe = selectedRecipe!!,
+                onBack = { viewModel.clearSelectedRecipe() },
+                showIngredients = showIngredients,
+                onTabChanged = { showIngredients = it }
+            )
+        } else {
+            HomeScreenContent(
+                viewModel = viewModel,
+                onNavigateToChat = onNavigateToChat,
+                onNavigateToCollection = onNavigateToCollection,
+                onNavigateToCommunity = onNavigateToCommunity,
+                onSignOut = onSignOut,
+                signedIn = !userSessionService.anonymousSession && currentUser != null
+            )
+        }
     }
 }
 
 @Composable
 private fun HomeScreenContent(
+    viewModel: HomeScreenViewModel,
     onNavigateToChat: () -> Unit,
     onNavigateToCollection: () -> Unit,
+    onNavigateToCommunity: () -> Unit,
     onSignOut: () -> Unit,
     signedIn: Boolean
 ) {
     val overlayViewModel: OverlayChatViewModel = viewModel(factory = OverlayChatViewModelFactory)
     var showChefOverlay by remember { mutableStateOf(false) }
+
+    val userRecipes by viewModel.userRecipes.collectAsState()
+    val communityRecipes by viewModel.communityRecipes.collectAsState()
+    val isLoadingRecipes by viewModel.isLoading.collectAsState()
 
     Scaffold(
         floatingActionButton = {
@@ -81,32 +120,116 @@ private fun HomeScreenContent(
             }
         }
     ) { paddingValues ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Button(
-                onClick = onNavigateToChat,
-                enabled = signedIn,
-                modifier = Modifier.padding(16.dp)
+        if (isLoadingRecipes) {
+            CircularProgressIndicator(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .wrapContentSize()
+            )
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .padding(horizontal = 16.dp)
             ) {
-                Text(text = "Go to Chat")
-            }
-            Button(
-                onClick = onNavigateToCollection,
-                modifier = Modifier.padding(16.dp)
-            ) {
-                Text(text = "View Collection")
-            }
+                item {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = "My Recipes",
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        TextButton(onClick = onNavigateToCollection) {
+                            Text("View all")
+                        }
+                    }
+                }
 
-            Button(
-                onClick = onSignOut,
-                modifier = Modifier.padding(16.dp)
-            ) {
-                Text(text = "Sign out")
+                if (userRecipes.isEmpty()) {
+                    item {
+                        Text(
+                            text = "No recipes yet. Start chatting to create some!",
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.padding(vertical = 8.dp)
+                        )
+                    }
+                } else {
+                    items(userRecipes) { recipe ->
+                        RecipeItem(
+                            recipe = recipe,
+                            onRecipeClick = viewModel::onRecipeSelected,
+                            onRecipeRemove = {},
+                            recipeRemoveEnabled = false,
+                            painter = rememberAsyncImagePainter(recipe.imageUrl)
+                        )
+                    }
+                }
+
+                item {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 16.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = "Community",
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        TextButton(onClick = onNavigateToCommunity) {
+                            Text("Browse all")
+                        }
+                    }
+                }
+
+                if (communityRecipes.isEmpty()) {
+                    item {
+                        Text(
+                            text = "No community recipes available yet.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.padding(vertical = 8.dp)
+                        )
+                    }
+                } else {
+                    items(communityRecipes) { recipe ->
+                        RecipeItem(
+                            recipe = recipe,
+                            onRecipeClick = viewModel::onRecipeSelected,
+                            onRecipeRemove = {},
+                            recipeRemoveEnabled = false,
+                            painter = rememberAsyncImagePainter(recipe.imageUrl)
+                        )
+                    }
+                }
+
+                item {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 16.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Button(
+                            onClick = onNavigateToChat,
+                            enabled = signedIn,
+                            modifier = Modifier.padding(4.dp)
+                        ) {
+                            Text(text = "Go to Chat")
+                        }
+                        Button(
+                            onClick = onSignOut,
+                            modifier = Modifier.padding(4.dp)
+                        ) {
+                            Text(text = "Sign out")
+                        }
+                    }
+                }
             }
         }
 
@@ -118,15 +241,4 @@ private fun HomeScreenContent(
             )
         }
     }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun PreviewHomeNavigationScreen() {
-    HomeScreenContent(
-        onNavigateToChat = {},
-        onNavigateToCollection = {},
-        onSignOut = {},
-        signedIn = true
-    )
 }

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/HomeScreen.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/HomeScreen.kt
@@ -64,8 +64,10 @@ fun HomeScreen(
         }
     }
 
-    LaunchedEffect(currentUser) {
-        viewModel.setCurrentUser(currentUser?.uid)
+    LaunchedEffect(isLoading, currentUser?.uid) {
+        if (!isLoading) {
+            viewModel.setCurrentUser(currentUser?.uid)
+        }
     }
 
     val selectedRecipe by viewModel.selectedRecipe.collectAsState()
@@ -82,7 +84,8 @@ fun HomeScreen(
                 recipe = selectedRecipe!!,
                 onBack = { viewModel.clearSelectedRecipe() },
                 showIngredients = showIngredients,
-                onTabChanged = { showIngredients = it }
+                onTabChanged = { showIngredients = it },
+                isOwner = currentUser?.uid == selectedRecipe?.uid
             )
         } else {
             HomeScreenContent(

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/HomeScreenViewModelFactory.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/HomeScreenViewModelFactory.kt
@@ -1,0 +1,18 @@
+package com.formulae.chef
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.formulae.chef.feature.home.HomeScreenViewModel
+import com.formulae.chef.services.persistence.RecipeRepository
+
+class HomeScreenViewModelFactory(
+    private val repository: RecipeRepository
+) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(HomeScreenViewModel::class.java)) {
+            return HomeScreenViewModel(repository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/CollectionScreen.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/CollectionScreen.kt
@@ -108,7 +108,8 @@ internal fun CollectionRoute(
     listRepository: RecipeListRepository,
     collectionViewModel: CollectionViewModel,
     navController: NavController,
-    userSessionService: UserSessionService
+    userSessionService: UserSessionService,
+    initialRecipeSource: RecipeSource = RecipeSource.USER_FAVOURITES
 ) {
     val collectionUiState by collectionViewModel.uiState.collectAsState()
     val isLoading by collectionViewModel.isLoading.collectAsState()
@@ -137,10 +138,12 @@ internal fun CollectionRoute(
 
     val signedIn = !userSessionService.anonymousSession && currentUser != null
 
-    var recipesSource by rememberSaveable { mutableStateOf(RecipeSource.ALL_RECIPES) }
+    var recipesSource by rememberSaveable { mutableStateOf(initialRecipeSource) }
 
     LaunchedEffect(signedIn) {
-        recipesSource = if (signedIn) RecipeSource.USER_FAVOURITES else RecipeSource.ALL_RECIPES
+        if (initialRecipeSource == RecipeSource.USER_FAVOURITES) {
+            recipesSource = if (signedIn) RecipeSource.USER_FAVOURITES else RecipeSource.ALL_RECIPES
+        }
     }
 
     LaunchedEffect(currentUser) {

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/home/HomeScreenViewModel.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/home/HomeScreenViewModel.kt
@@ -1,5 +1,6 @@
 package com.formulae.chef.feature.home
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.formulae.chef.feature.model.Recipe
@@ -25,10 +26,7 @@ class HomeScreenViewModel(
     private val _selectedRecipe = MutableStateFlow<Recipe?>(null)
     val selectedRecipe: StateFlow<Recipe?> = _selectedRecipe.asStateFlow()
 
-    private var currentUid: String? = null
-
     fun setCurrentUser(uid: String?) {
-        currentUid = uid
         viewModelScope.launch { fetchRecipes(uid) }
     }
 
@@ -42,17 +40,26 @@ class HomeScreenViewModel(
 
     private suspend fun fetchRecipes(uid: String?) {
         _isLoading.value = true
-        val all = repository.loadAllRecipes()
-        _userRecipes.value = all.filter { it.uid == uid }.shuffled().take(USER_RECIPE_COUNT)
-        _communityRecipes.value = all
-            .filter { it.isFavourite && it.copyId == null && it.uid != uid }
-            .shuffled()
-            .take(COMMUNITY_RECIPE_COUNT)
-        _isLoading.value = false
+        try {
+            val all = repository.loadAllRecipes()
+            _userRecipes.value = all
+                .filter { it.uid == uid && it.isFavourite }
+                .shuffled()
+                .take(USER_RECIPE_COUNT)
+            _communityRecipes.value = all
+                .filter { it.isFavourite && it.copyId == null && it.uid != uid }
+                .shuffled()
+                .take(COMMUNITY_RECIPE_COUNT)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to load recipes for dashboard", e)
+        } finally {
+            _isLoading.value = false
+        }
     }
 
     companion object {
         const val USER_RECIPE_COUNT = 2
         const val COMMUNITY_RECIPE_COUNT = 6
+        private const val TAG = "HomeScreenViewModel"
     }
 }

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/home/HomeScreenViewModel.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/home/HomeScreenViewModel.kt
@@ -1,0 +1,58 @@
+package com.formulae.chef.feature.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.formulae.chef.feature.model.Recipe
+import com.formulae.chef.services.persistence.RecipeRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class HomeScreenViewModel(
+    private val repository: RecipeRepository
+) : ViewModel() {
+
+    private val _userRecipes = MutableStateFlow<List<Recipe>>(emptyList())
+    val userRecipes: StateFlow<List<Recipe>> = _userRecipes.asStateFlow()
+
+    private val _communityRecipes = MutableStateFlow<List<Recipe>>(emptyList())
+    val communityRecipes: StateFlow<List<Recipe>> = _communityRecipes.asStateFlow()
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    private val _selectedRecipe = MutableStateFlow<Recipe?>(null)
+    val selectedRecipe: StateFlow<Recipe?> = _selectedRecipe.asStateFlow()
+
+    private var currentUid: String? = null
+
+    fun setCurrentUser(uid: String?) {
+        currentUid = uid
+        viewModelScope.launch { fetchRecipes(uid) }
+    }
+
+    fun onRecipeSelected(recipe: Recipe) {
+        _selectedRecipe.value = recipe
+    }
+
+    fun clearSelectedRecipe() {
+        _selectedRecipe.value = null
+    }
+
+    private suspend fun fetchRecipes(uid: String?) {
+        _isLoading.value = true
+        val all = repository.loadAllRecipes()
+        _userRecipes.value = all.filter { it.uid == uid }.shuffled().take(USER_RECIPE_COUNT)
+        _communityRecipes.value = all
+            .filter { it.isFavourite && it.copyId == null && it.uid != uid }
+            .shuffled()
+            .take(COMMUNITY_RECIPE_COUNT)
+        _isLoading.value = false
+    }
+
+    companion object {
+        const val USER_RECIPE_COUNT = 2
+        const val COMMUNITY_RECIPE_COUNT = 6
+    }
+}

--- a/vertexai/app/src/test/kotlin/com/formulae/chef/feature/home/HomeScreenViewModelTest.kt
+++ b/vertexai/app/src/test/kotlin/com/formulae/chef/feature/home/HomeScreenViewModelTest.kt
@@ -1,0 +1,153 @@
+package com.formulae.chef.feature.home
+
+import com.formulae.chef.feature.model.Recipe
+import com.formulae.chef.services.persistence.RecipeRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeScreenViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    // user-1 owns 3 recipes; user-2 owns 2 favourites (community candidates)
+    private val userUid = "user-1"
+    private val otherUid = "user-2"
+
+    private val userRecipes = (1..3).map { i ->
+        Recipe(id = "u$i", uid = userUid, title = "User Recipe $i")
+    }
+    private val communityRecipes = (1..8).map { i ->
+        Recipe(id = "c$i", uid = otherUid, title = "Community Recipe $i", isFavourite = true)
+    }
+    private val nonFavouriteOtherRecipe =
+        Recipe(id = "nf1", uid = otherUid, title = "Not Favourite", isFavourite = false)
+    private val copyRecipe =
+        Recipe(id = "cp1", uid = otherUid, title = "Copy Recipe", isFavourite = true, copyId = "c1")
+
+    private val allRecipes = userRecipes + communityRecipes + nonFavouriteOtherRecipe + copyRecipe
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun makeViewModel(recipes: List<Recipe> = allRecipes): HomeScreenViewModel =
+        HomeScreenViewModel(FakeRecipeRepository(recipes))
+
+    @Test
+    fun `setCurrentUser filters user recipes and caps at USER_RECIPE_COUNT`() = runTest(testDispatcher) {
+        val viewModel = makeViewModel()
+
+        viewModel.setCurrentUser(userUid)
+        advanceUntilIdle()
+
+        val result = viewModel.userRecipes.value
+        assertTrue(result.all { it.uid == userUid })
+        assertTrue(result.size <= HomeScreenViewModel.USER_RECIPE_COUNT)
+    }
+
+    @Test
+    fun `setCurrentUser filters community recipes — isFavourite, no copyId, not owned`() = runTest(testDispatcher) {
+        val viewModel = makeViewModel()
+
+        viewModel.setCurrentUser(userUid)
+        advanceUntilIdle()
+
+        val result = viewModel.communityRecipes.value
+        assertTrue(result.all { it.isFavourite })
+        assertTrue(result.all { it.copyId == null })
+        assertTrue(result.all { it.uid != userUid })
+        assertTrue(result.size <= HomeScreenViewModel.COMMUNITY_RECIPE_COUNT)
+    }
+
+    @Test
+    fun `community recipes caps at COMMUNITY_RECIPE_COUNT when more are available`() = runTest(testDispatcher) {
+        val viewModel = makeViewModel()
+
+        viewModel.setCurrentUser(userUid)
+        advanceUntilIdle()
+
+        assertEquals(HomeScreenViewModel.COMMUNITY_RECIPE_COUNT, viewModel.communityRecipes.value.size)
+    }
+
+    @Test
+    fun `null uid returns empty user recipes but still returns community recipes`() = runTest(testDispatcher) {
+        val viewModel = makeViewModel()
+
+        viewModel.setCurrentUser(null)
+        advanceUntilIdle()
+
+        assertTrue(viewModel.userRecipes.value.isEmpty())
+        assertTrue(viewModel.communityRecipes.value.isNotEmpty())
+    }
+
+    @Test
+    fun `isLoading is false after fetch completes`() = runTest(testDispatcher) {
+        val viewModel = makeViewModel()
+
+        viewModel.setCurrentUser(userUid)
+        advanceUntilIdle()
+
+        assertFalse(viewModel.isLoading.value)
+    }
+
+    @Test
+    fun `onRecipeSelected sets selectedRecipe`() = runTest(testDispatcher) {
+        val viewModel = makeViewModel()
+        val recipe = userRecipes[0]
+
+        viewModel.onRecipeSelected(recipe)
+
+        assertEquals(recipe, viewModel.selectedRecipe.value)
+    }
+
+    @Test
+    fun `clearSelectedRecipe clears selectedRecipe`() = runTest(testDispatcher) {
+        val viewModel = makeViewModel()
+        viewModel.onRecipeSelected(userRecipes[0])
+
+        viewModel.clearSelectedRecipe()
+
+        assertNull(viewModel.selectedRecipe.value)
+    }
+
+    @Test
+    fun `non-favourite and copy recipes are excluded from community`() = runTest(testDispatcher) {
+        val viewModel = makeViewModel()
+
+        viewModel.setCurrentUser(userUid)
+        advanceUntilIdle()
+
+        val ids = viewModel.communityRecipes.value.map { it.id }
+        assertFalse(ids.contains("nf1"))
+        assertFalse(ids.contains("cp1"))
+    }
+}
+
+private class FakeRecipeRepository(
+    private val recipes: List<Recipe>
+) : RecipeRepository {
+    override fun saveRecipe(recipe: Recipe) = Unit
+    override suspend fun loadUserRecipes(uid: String): List<Recipe> = recipes.filter { it.uid == uid }
+    override suspend fun loadAllRecipes(): List<Recipe> = recipes
+    override fun removeRecipe(recipeId: String) = Unit
+    override fun removeRecipeUid(recipeId: String) = Unit
+}

--- a/vertexai/app/src/test/kotlin/com/formulae/chef/feature/home/HomeScreenViewModelTest.kt
+++ b/vertexai/app/src/test/kotlin/com/formulae/chef/feature/home/HomeScreenViewModelTest.kt
@@ -22,13 +22,15 @@ class HomeScreenViewModelTest {
 
     private val testDispatcher = StandardTestDispatcher()
 
-    // user-1 owns 3 recipes; user-2 owns 2 favourites (community candidates)
     private val userUid = "user-1"
     private val otherUid = "user-2"
 
-    private val userRecipes = (1..3).map { i ->
-        Recipe(id = "u$i", uid = userUid, title = "User Recipe $i")
+    // 2 favourite user recipes, 1 non-favourite user recipe
+    private val userFavouriteRecipes = (1..2).map { i ->
+        Recipe(id = "u$i", uid = userUid, title = "User Recipe $i", isFavourite = true)
     }
+    private val userNonFavouriteRecipe =
+        Recipe(id = "u3", uid = userUid, title = "User Recipe 3", isFavourite = false)
     private val communityRecipes = (1..8).map { i ->
         Recipe(id = "c$i", uid = otherUid, title = "Community Recipe $i", isFavourite = true)
     }
@@ -37,7 +39,8 @@ class HomeScreenViewModelTest {
     private val copyRecipe =
         Recipe(id = "cp1", uid = otherUid, title = "Copy Recipe", isFavourite = true, copyId = "c1")
 
-    private val allRecipes = userRecipes + communityRecipes + nonFavouriteOtherRecipe + copyRecipe
+    private val allRecipes =
+        userFavouriteRecipes + userNonFavouriteRecipe + communityRecipes + nonFavouriteOtherRecipe + copyRecipe
 
     @Before
     fun setup() {
@@ -53,7 +56,7 @@ class HomeScreenViewModelTest {
         HomeScreenViewModel(FakeRecipeRepository(recipes))
 
     @Test
-    fun `setCurrentUser filters user recipes and caps at USER_RECIPE_COUNT`() = runTest(testDispatcher) {
+    fun `setCurrentUser filters user recipes to own favourites and caps at USER_RECIPE_COUNT`() = runTest(testDispatcher) {
         val viewModel = makeViewModel()
 
         viewModel.setCurrentUser(userUid)
@@ -61,7 +64,18 @@ class HomeScreenViewModelTest {
 
         val result = viewModel.userRecipes.value
         assertTrue(result.all { it.uid == userUid })
+        assertTrue(result.all { it.isFavourite })
         assertTrue(result.size <= HomeScreenViewModel.USER_RECIPE_COUNT)
+    }
+
+    @Test
+    fun `non-favourite user recipes are excluded from My Recipes`() = runTest(testDispatcher) {
+        val viewModel = makeViewModel()
+
+        viewModel.setCurrentUser(userUid)
+        advanceUntilIdle()
+
+        assertFalse(viewModel.userRecipes.value.any { it.id == "u3" })
     }
 
     @Test
@@ -112,7 +126,7 @@ class HomeScreenViewModelTest {
     @Test
     fun `onRecipeSelected sets selectedRecipe`() = runTest(testDispatcher) {
         val viewModel = makeViewModel()
-        val recipe = userRecipes[0]
+        val recipe = userFavouriteRecipes[0]
 
         viewModel.onRecipeSelected(recipe)
 
@@ -122,7 +136,7 @@ class HomeScreenViewModelTest {
     @Test
     fun `clearSelectedRecipe clears selectedRecipe`() = runTest(testDispatcher) {
         val viewModel = makeViewModel()
-        viewModel.onRecipeSelected(userRecipes[0])
+        viewModel.onRecipeSelected(userFavouriteRecipes[0])
 
         viewModel.clearSelectedRecipe()
 


### PR DESCRIPTION
## Summary

- Add `HomeScreenViewModel` (`feature/home/`) with `setCurrentUser(uid)` that fetches all recipes and exposes 2 random user recipes and 6 random community recipes (filtered by `isFavourite && copyId == null && uid != currentUid`)
- Update `HomeScreen` to display "My Recipes" and "Community" sections as `RecipeItem` cards; tapping a card shows `DetailRoute` (same pattern as `ChatRoute`)
- Add `onNavigateToCommunity` callback — navigates to the Collection screen with the Browse tab pre-selected via a `?tab=` nav argument
- Extend `CollectionRoute` with `initialRecipeSource` parameter so the community deep-link opens on the correct tab without the sign-in `LaunchedEffect` overriding it
- Add `HomeScreenViewModelFactory`

## Gitignored files required for reviewers

- `local.properties` (`firebaseDbUrl`, `phoenixApiKey`, `gcpTtsApiKey`)
- `vertexai/app/google-services.json`
- `vertexai/app/src/main/assets/gcp.json`
- `vertexai/app/src/main/assets/imagen-google-services.json`
- `vertexai/app/src/main/assets/chat_system_prompt.txt`

## Test plan

- [ ] `./gradlew ktlintCheck` — passes
- [ ] `./gradlew :vertexai:app:assembleDebug` — passes
- [ ] `./gradlew :vertexai:app:testDebugUnitTest` — passes (8 new tests in `HomeScreenViewModelTest`)
- [ ] Launch app signed-in → home screen shows up to 2 user recipe cards under "My Recipes"
- [ ] "View all" button navigates to Collection (user favourites tab)
- [ ] Up to 6 community recipe cards appear under "Community"
- [ ] "Browse all" button navigates to Collection with **Browse tab pre-selected**
- [ ] Tap a recipe card → recipe detail view opens; back button returns to home
- [ ] Launch as anonymous user → "My Recipes" shows empty state message; community cards still show
- [ ] FAB (Chat overlay) still works as before

Closes CHE-17