### PR TITLE
CHE-29: Recipe of the Month video

### DIFF
--- a/.ai/database-schema.md
+++ b/.ai/database-schema.md
@@ -6,8 +6,10 @@ Derived from `vertexai/app/src/main/assets/idyllic-bloom-425307-r6-default-rtdb-
 
 ```
 ROOT
-├── recipes    — all recipe objects, keyed by Firebase push ID
-└── users      — user profiles keyed by Firebase Auth UID
+├── recipes                  — all recipe objects, keyed by Firebase push ID
+├── recipe_of_the_month      — monthly featured recipe entries, keyed by Firebase push ID
+├── video_generation_history — permanent set of recipe IDs that have been featured; never deleted
+└── users                    — user profiles keyed by Firebase Auth UID
 ```
 
 ---
@@ -28,6 +30,7 @@ Recipe {
   prepTime:           string        // e.g. "20 minutes", or "" if unset
   servings:           string        // e.g. "4 servings", "2 portions"
   imageUrl:           string        // Firebase Storage HTTPS URL
+  videoUrl:           string?       // Firebase Storage HTTPS URL to Recipe of the Month video; absent or null if not selected
   isFavourite:        boolean
   tipsAndTricks:      string        // Free-text tips (may be empty "")
   updatedAt:          string        // ISO 8601 timestamp, e.g. "2025-02-12T13:58:18.650875+00:00"
@@ -179,6 +182,32 @@ Tags are optional and absent on recipes created before CHE-12 unless retroactive
 
 ---
 
+## `recipe_of_the_month` Node
+
+**Path:** `recipe_of_the_month/{pushId}`
+Written by the `rotw-job` Cloud Run job on the first Sunday of each month (CHE-29).
+
+```
+RecipeOfTheMonth {
+  recipeId:    string    // push ID of the selected recipe in `recipes`
+  recipeTitle: string    // recipe title (denormalised for fast home screen render)
+  videoUrl:    string    // Firebase Storage HTTPS URL, e.g. videos/rotw/2026-04.mp4
+  monthOf:     string    // "YYYY-MM", e.g. "2026-04"
+  createdAt:   string    // ISO 8601 timestamp
+}
+```
+
+---
+
+## `video_generation_history` Node
+
+**Path:** `video_generation_history/{recipeId}: true`
+Permanent record of every recipe ID that has been selected for a Recipe of the Month video.
+Written by `rotw-job` at generation time. **Never deleted** — ensures the same recipe is never
+featured twice, even if `recipe_of_the_month` entries are cleaned up.
+
+---
+
 ## Field Type Reference
 
 | Field | Type | Notes                                                                         |
@@ -193,6 +222,7 @@ Tags are optional and absent on recipes created before CHE-12 unless retroactive
 | `unit` (ingredient/nutrient) | string | May be empty string                                                           |
 | `role` (chat) | string (enum) | "user" or "model"                                                             |
 | `imageUrl` | string | `https://storage.googleapis.com/{PROJECT_ID}.firebasestorage.app/recipes/...` |
+| `videoUrl` | string? | Firebase Storage URL to ROTW video; absent/null on recipes not selected       |
 | `tags` | string[] | Optional; absent on pre-CHE-12 recipes. All values lowercase. |
 
 ---

--- a/backend/rotw-job/README.md
+++ b/backend/rotw-job/README.md
@@ -1,0 +1,114 @@
+# rotw-job — Recipe of the Month Video Generator
+
+A Cloud Run Job that runs monthly to:
+1. Pick a random favourite recipe that has never been featured before
+2. Generate a 15-second cinematic food video via **Google Veo 2** (Vertex AI)
+3. Upload the video to **Firebase Storage** under `videos/rotw/YYYY-MM.mp4`
+4. Write a record to the `recipe_of_the_month` RTDB node
+5. Update `videoUrl` on the selected recipe in the `recipes` RTDB node
+6. Mark the recipe as used in `video_generation_history` so it is never selected again
+
+## Prerequisites
+
+- JDK 17
+- A GCP project with the **Vertex AI API** enabled
+- A Firebase project (Realtime Database + Storage)
+- A service account with the following roles:
+  - `roles/aiplatform.user` — for Veo 2 video generation
+  - `roles/firebase.admin` — for RTDB reads/writes
+  - `roles/storage.objectAdmin` — for Firebase Storage uploads
+- The service account key exported as a JSON file (for local runs)
+
+## Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `GOOGLE_APPLICATION_CREDENTIALS` | Yes | Absolute path to service account key JSON |
+| `GCP_PROJECT_ID` | Yes | GCP project ID (e.g. `my-project-123`) |
+| `FIREBASE_DB_URL` | Yes | Firebase RTDB URL (e.g. `https://my-project-default-rtdb.firebaseio.com`) |
+| `FIREBASE_STORAGE_BUCKET` | Yes | Firebase Storage bucket (e.g. `my-project.appspot.com`) |
+| `GCP_LOCATION` | No | Vertex AI region (default: `us-central1`) |
+
+## Running locally
+
+```bash
+# From the repo root
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+export GCP_PROJECT_ID=my-project-123
+export FIREBASE_DB_URL=https://my-project-default-rtdb.firebaseio.com
+export FIREBASE_STORAGE_BUCKET=my-project.appspot.com
+
+./gradlew :backend:rotw-job:run
+```
+
+> **Note:** A real run generates a video via Veo 2, which costs ~$5.25/video. Only run against production credentials when you intend to produce an actual video.
+
+## Running tests (no API calls, no cost)
+
+```bash
+./gradlew :backend:rotw-job:test
+```
+
+The test suite covers `selectRecipe()` (recipe selection logic) and `GeminiPromptBuilder` (prompt construction). Both are pure functions with no external dependencies.
+
+## Building and pushing the container image
+
+The project uses [Jib](https://github.com/GoogleContainerTools/jib) for containerisation — no local Docker daemon required.
+
+```bash
+export GCP_PROJECT_ID=my-project-123
+
+# Build and push to Google Artifact Registry / Container Registry
+./gradlew :backend:rotw-job:jib
+```
+
+This produces image `gcr.io/$GCP_PROJECT_ID/rotw-job:latest`.
+
+## Deploying as a Cloud Run Job
+
+```bash
+gcloud run jobs create rotw-job \
+  --image gcr.io/$GCP_PROJECT_ID/rotw-job \
+  --region us-central1 \
+  --service-account rotw-job@$GCP_PROJECT_ID.iam.gserviceaccount.com \
+  --set-env-vars "GCP_PROJECT_ID=$GCP_PROJECT_ID,FIREBASE_DB_URL=...,FIREBASE_STORAGE_BUCKET=..." \
+  --set-secrets "GOOGLE_APPLICATION_CREDENTIALS=rotw-sa-key:latest"
+```
+
+### Scheduled execution
+
+The job is intended to run on the **first Sunday of each month at 22:00 UTC**:
+
+```bash
+gcloud scheduler jobs create http rotw-monthly \
+  --schedule "0 22 1-7 * 0" \
+  --uri "https://us-central1-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/$GCP_PROJECT_ID/jobs/rotw-job:run" \
+  --oauth-service-account-email rotw-scheduler@$GCP_PROJECT_ID.iam.gserviceaccount.com \
+  --location us-central1
+```
+
+## Firebase RTDB schema written by this job
+
+```
+recipe_of_the_month/
+  {pushId}/
+    recipeId:    string   # ID of the selected recipe
+    recipeTitle: string
+    videoUrl:    string   # Firebase Storage HTTPS download URL
+    monthOf:     string   # "YYYY-MM"
+    createdAt:   string   # ISO-8601 timestamp
+
+video_generation_history/
+  {recipeId}: true        # permanent; never deleted
+```
+
+The `recipes/{id}/videoUrl` field is also updated on the selected recipe so the Android app can show the video in the recipe detail screen.
+
+## Cost
+
+| Item | Cost |
+|---|---|
+| Veo 2 video generation (15s) | ~$5.25 per run |
+| Firebase Storage (video retained indefinitely) | ~$0.026/GB/month |
+| Cloud Run Job execution | negligible |
+| Cloud Scheduler | free tier |

--- a/backend/rotw-job/README.md
+++ b/backend/rotw-job/README.md
@@ -27,7 +27,7 @@ A Cloud Run Job that runs monthly to:
 | `GCP_PROJECT_ID` | Yes | GCP project ID (e.g. `my-project-123`) |
 | `FIREBASE_DB_URL` | Yes | Firebase RTDB URL (e.g. `https://my-project-default-rtdb.firebaseio.com`) |
 | `FIREBASE_STORAGE_BUCKET` | Yes | Firebase Storage bucket (e.g. `my-project.appspot.com`) |
-| `GCP_LOCATION` | No | Vertex AI region (default: `us-central1`) |
+| `GCP_LOCATION` | Yes | Vertex AI region (e.g. `europe-west1`) |
 
 ## Running locally
 
@@ -35,6 +35,7 @@ A Cloud Run Job that runs monthly to:
 # From the repo root
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 export GCP_PROJECT_ID=my-project-123
+export GCP_LOCATION=europe-west1
 export FIREBASE_DB_URL=https://my-project-default-rtdb.firebaseio.com
 export FIREBASE_STORAGE_BUCKET=my-project.appspot.com
 
@@ -67,11 +68,13 @@ This produces image `gcr.io/$GCP_PROJECT_ID/rotw-job:latest`.
 ## Deploying as a Cloud Run Job
 
 ```bash
+export GCP_REGION=europe-west1
+
 gcloud run jobs create rotw-job \
   --image gcr.io/$GCP_PROJECT_ID/rotw-job \
-  --region us-central1 \
+  --region $GCP_REGION \
   --service-account rotw-job@$GCP_PROJECT_ID.iam.gserviceaccount.com \
-  --set-env-vars "GCP_PROJECT_ID=$GCP_PROJECT_ID,FIREBASE_DB_URL=...,FIREBASE_STORAGE_BUCKET=..." \
+  --set-env-vars "GCP_PROJECT_ID=$GCP_PROJECT_ID,GCP_LOCATION=$GCP_REGION,FIREBASE_DB_URL=...,FIREBASE_STORAGE_BUCKET=..." \
   --set-secrets "GOOGLE_APPLICATION_CREDENTIALS=rotw-sa-key:latest"
 ```
 
@@ -82,9 +85,9 @@ The job is intended to run on the **first Sunday of each month at 22:00 UTC**:
 ```bash
 gcloud scheduler jobs create http rotw-monthly \
   --schedule "0 22 1-7 * 0" \
-  --uri "https://us-central1-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/$GCP_PROJECT_ID/jobs/rotw-job:run" \
+  --uri "https://$GCP_REGION-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/$GCP_PROJECT_ID/jobs/rotw-job:run" \
   --oauth-service-account-email rotw-scheduler@$GCP_PROJECT_ID.iam.gserviceaccount.com \
-  --location us-central1
+  --location $GCP_REGION
 ```
 
 ## Firebase RTDB schema written by this job

--- a/backend/rotw-job/build.gradle.kts
+++ b/backend/rotw-job/build.gradle.kts
@@ -1,0 +1,43 @@
+plugins {
+    id("org.jetbrains.kotlin.jvm")
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.1.20"
+    id("com.google.cloud.tools.jib")
+    application
+}
+
+kotlin {
+    jvmToolchain(17)
+}
+
+application {
+    mainClass.set("com.formulae.chef.rotw.MainKt")
+}
+
+dependencies {
+    implementation("com.google.firebase:firebase-admin:9.4.2")
+    implementation("com.google.auth:google-auth-library-oauth2-http:1.23.0")
+    implementation("io.ktor:ktor-client-cio:2.3.12")
+    implementation("io.ktor:ktor-client-content-negotiation:2.3.12")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.12")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+    implementation("org.slf4j:slf4j-simple:2.0.16")
+
+    testImplementation(kotlin("test"))
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
+}
+
+val gcpProjectId: String = System.getenv("GCP_PROJECT_ID") ?: "YOUR_PROJECT_ID"
+
+jib {
+    from {
+        image = "eclipse-temurin:17-jre"
+    }
+    to {
+        image = "gcr.io/$gcpProjectId/rotw-job"
+    }
+    container {
+        mainClass = "com.formulae.chef.rotw.MainKt"
+        jvmFlags = listOf("-Xms256m", "-Xmx512m")
+    }
+}

--- a/backend/rotw-job/src/main/kotlin/com/formulae/chef/rotw/Main.kt
+++ b/backend/rotw-job/src/main/kotlin/com/formulae/chef/rotw/Main.kt
@@ -1,0 +1,8 @@
+package com.formulae.chef.rotw
+
+import com.formulae.chef.rotw.job.RecipeOfTheMonthJob
+import kotlinx.coroutines.runBlocking
+
+fun main() = runBlocking {
+    RecipeOfTheMonthJob().execute()
+}

--- a/backend/rotw-job/src/main/kotlin/com/formulae/chef/rotw/job/RecipeOfTheMonthJob.kt
+++ b/backend/rotw-job/src/main/kotlin/com/formulae/chef/rotw/job/RecipeOfTheMonthJob.kt
@@ -5,6 +5,8 @@ import com.formulae.chef.rotw.model.RecipeOfTheMonthRecord
 import com.formulae.chef.rotw.service.FirebaseAdminService
 import com.formulae.chef.rotw.service.GeminiPromptBuilder
 import com.formulae.chef.rotw.service.VeoClient
+import java.nio.file.Files
+import java.nio.file.Path
 import java.time.Instant
 import java.time.YearMonth
 import java.time.ZoneOffset
@@ -39,25 +41,44 @@ class RecipeOfTheMonthJob(
         val prompt = geminiPromptBuilder.buildPrompt(selected)
         logger.info("Generated Veo 2 prompt: ${prompt.take(100)}...")
 
+        val monthOf = YearMonth.now(ZoneOffset.UTC).toString()
         val videoBytes = veoClient.generateVideo(prompt, durationSeconds = 15)
         logger.info("Video generated: ${videoBytes.size} bytes")
 
-        val monthOf = YearMonth.now(ZoneOffset.UTC).toString()
-        val videoUrl = firebaseAdminService.uploadVideo(videoBytes, monthOf)
+        try {
+            val videoUrl = firebaseAdminService.uploadVideo(videoBytes, monthOf)
 
-        val record = RecipeOfTheMonthRecord(
-            recipeId = selected.id,
-            recipeTitle = selected.title,
-            videoUrl = videoUrl,
-            monthOf = monthOf,
-            createdAt = Instant.now().toString()
-        )
+            val record = RecipeOfTheMonthRecord(
+                recipeId = selected.id,
+                recipeTitle = selected.title,
+                videoUrl = videoUrl,
+                monthOf = monthOf,
+                createdAt = Instant.now().toString()
+            )
 
-        firebaseAdminService.writeRecipeOfTheMonth(record)
-        firebaseAdminService.markRecipeSelected(selected.id)
-        firebaseAdminService.updateRecipeVideoUrl(selected.id, videoUrl)
+            firebaseAdminService.writeRecipeOfTheMonth(record)
+            firebaseAdminService.markRecipeSelected(selected.id)
+            firebaseAdminService.updateRecipeVideoUrl(selected.id, videoUrl)
 
-        logger.info("Recipe of the Month job complete. Recipe: ${selected.title}, Month: $monthOf")
+            logger.info("Recipe of the Month job complete. Recipe: ${selected.title}, Month: $monthOf")
+        } catch (e: Exception) {
+            // Veo 2 generation already completed (~$5.25 cost incurred). Attempt to preserve
+            // the video bytes to /tmp so they survive for the duration of this Cloud Run Job
+            // execution and can be manually re-uploaded without re-running Veo 2.
+            try {
+                val tempFile: Path = Files.createTempFile("rotw-$monthOf-", ".mp4")
+                Files.write(tempFile, videoBytes)
+                logger.error(
+                    "Upload or RTDB write failed. Video preserved at $tempFile — " +
+                        "re-upload manually to Firebase Storage at videos/rotw/$monthOf.mp4 " +
+                        "and write the recipe_of_the_month record by hand. Recipe: ${selected.id}",
+                    e
+                )
+            } catch (ioException: Exception) {
+                logger.error("Failed to preserve video bytes to /tmp after upload failure", ioException)
+            }
+            throw e
+        }
     }
 }
 

--- a/backend/rotw-job/src/main/kotlin/com/formulae/chef/rotw/job/RecipeOfTheMonthJob.kt
+++ b/backend/rotw-job/src/main/kotlin/com/formulae/chef/rotw/job/RecipeOfTheMonthJob.kt
@@ -1,0 +1,73 @@
+package com.formulae.chef.rotw.job
+
+import com.formulae.chef.rotw.model.RecipeData
+import com.formulae.chef.rotw.model.RecipeOfTheMonthRecord
+import com.formulae.chef.rotw.service.FirebaseAdminService
+import com.formulae.chef.rotw.service.GeminiPromptBuilder
+import com.formulae.chef.rotw.service.VeoClient
+import java.time.Instant
+import java.time.YearMonth
+import java.time.ZoneOffset
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger(RecipeOfTheMonthJob::class.java)
+
+class RecipeOfTheMonthJob(
+    private val firebaseAdminService: FirebaseAdminService = FirebaseAdminService(),
+    private val veoClient: VeoClient = VeoClient(),
+    private val geminiPromptBuilder: GeminiPromptBuilder = GeminiPromptBuilder()
+) {
+    suspend fun execute() {
+        logger.info("Starting Recipe of the Month job")
+
+        val favourites = firebaseAdminService.loadFavouriteRecipes()
+        logger.info("Loaded ${favourites.size} favourite recipes")
+
+        val alreadySelected = firebaseAdminService.loadSelectedRecipeIds()
+        logger.info("Already selected recipe IDs: ${alreadySelected.size}")
+
+        val selected = selectRecipe(favourites, alreadySelected)
+        if (selected == null) {
+            logger.warn(
+                "No eligible recipes available — all favourites have already been featured. Skipping this month."
+            )
+            return
+        }
+
+        logger.info("Selected recipe: ${selected.id} — ${selected.title}")
+
+        val prompt = geminiPromptBuilder.buildPrompt(selected)
+        logger.info("Generated Veo 2 prompt: ${prompt.take(100)}...")
+
+        val videoBytes = veoClient.generateVideo(prompt, durationSeconds = 15)
+        logger.info("Video generated: ${videoBytes.size} bytes")
+
+        val monthOf = YearMonth.now(ZoneOffset.UTC).toString()
+        val videoUrl = firebaseAdminService.uploadVideo(videoBytes, monthOf)
+
+        val record = RecipeOfTheMonthRecord(
+            recipeId = selected.id,
+            recipeTitle = selected.title,
+            videoUrl = videoUrl,
+            monthOf = monthOf,
+            createdAt = Instant.now().toString()
+        )
+
+        firebaseAdminService.writeRecipeOfTheMonth(record)
+        firebaseAdminService.markRecipeSelected(selected.id)
+        firebaseAdminService.updateRecipeVideoUrl(selected.id, videoUrl)
+
+        logger.info("Recipe of the Month job complete. Recipe: ${selected.title}, Month: $monthOf")
+    }
+}
+
+/**
+ * Selects a random favourite recipe that has not previously been featured.
+ * Pure function — no side effects, fully unit-testable.
+ */
+fun selectRecipe(
+    favourites: List<RecipeData>,
+    alreadySelected: Set<String>
+): RecipeData? = favourites
+    .filter { it.id !in alreadySelected }
+    .randomOrNull()

--- a/backend/rotw-job/src/main/kotlin/com/formulae/chef/rotw/model/RecipeData.kt
+++ b/backend/rotw-job/src/main/kotlin/com/formulae/chef/rotw/model/RecipeData.kt
@@ -1,0 +1,19 @@
+package com.formulae.chef.rotw.model
+
+/**
+ * Lightweight recipe representation for backend use.
+ * Maps to the Firebase RTDB `recipes/{id}` node.
+ * Uses mutable var fields with default values for Firebase Admin SDK deserialization.
+ */
+data class RecipeData(
+    var id: String = "",
+    var title: String = "",
+    var ingredients: List<IngredientData> = emptyList(),
+    var isFavourite: Boolean = false
+)
+
+data class IngredientData(
+    var name: String? = "",
+    var quantity: String? = "",
+    var unit: String? = ""
+)

--- a/backend/rotw-job/src/main/kotlin/com/formulae/chef/rotw/model/RecipeOfTheMonthRecord.kt
+++ b/backend/rotw-job/src/main/kotlin/com/formulae/chef/rotw/model/RecipeOfTheMonthRecord.kt
@@ -1,0 +1,12 @@
+package com.formulae.chef.rotw.model
+
+/**
+ * Record written to `recipe_of_the_month/{pushId}` in Firebase RTDB.
+ */
+data class RecipeOfTheMonthRecord(
+    val recipeId: String,
+    val recipeTitle: String,
+    val videoUrl: String,
+    val monthOf: String,
+    val createdAt: String
+)

--- a/backend/rotw-job/src/main/kotlin/com/formulae/chef/rotw/service/FirebaseAdminService.kt
+++ b/backend/rotw-job/src/main/kotlin/com/formulae/chef/rotw/service/FirebaseAdminService.kt
@@ -1,0 +1,142 @@
+package com.formulae.chef.rotw.service
+
+import com.formulae.chef.rotw.model.IngredientData
+import com.formulae.chef.rotw.model.RecipeData
+import com.formulae.chef.rotw.model.RecipeOfTheMonthRecord
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.cloud.storage.Acl
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.cloud.StorageClient
+import com.google.firebase.database.DataSnapshot
+import com.google.firebase.database.DatabaseError
+import com.google.firebase.database.DatabaseReference
+import com.google.firebase.database.FirebaseDatabase
+import com.google.firebase.database.ValueEventListener
+import java.io.ByteArrayInputStream
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger(FirebaseAdminService::class.java)
+
+private const val RECIPES_KEY = "recipes"
+private const val RECIPE_OF_THE_MONTH_KEY = "recipe_of_the_month"
+private const val VIDEO_HISTORY_KEY = "video_generation_history"
+private const val STORAGE_VIDEO_PATH = "videos/rotw"
+
+/**
+ * Firebase Admin SDK client for all RTDB and Storage operations performed by the rotw-job.
+ *
+ * Required env vars:
+ * - GOOGLE_APPLICATION_CREDENTIALS — path to service account JSON
+ * - FIREBASE_DB_URL — Firebase RTDB URL
+ * - FIREBASE_STORAGE_BUCKET — Firebase Storage bucket name (e.g. project-id.appspot.com)
+ */
+class FirebaseAdminService {
+    private val database: FirebaseDatabase
+    private val storageBucket: String
+
+    init {
+        val dbUrl = System.getenv("FIREBASE_DB_URL")
+            ?: error("FIREBASE_DB_URL env var not set")
+        storageBucket = System.getenv("FIREBASE_STORAGE_BUCKET")
+            ?: error("FIREBASE_STORAGE_BUCKET env var not set")
+
+        val options = FirebaseOptions.builder()
+            .setCredentials(GoogleCredentials.getApplicationDefault())
+            .setDatabaseUrl(dbUrl)
+            .setStorageBucket(storageBucket)
+            .build()
+
+        if (FirebaseApp.getApps().isEmpty()) {
+            FirebaseApp.initializeApp(options)
+        }
+
+        database = FirebaseDatabase.getInstance()
+    }
+
+    suspend fun loadFavouriteRecipes(): List<RecipeData> {
+        val snapshot = database.getReference(RECIPES_KEY).awaitGet()
+        return snapshot.children.mapNotNull { child ->
+            val isFavourite = child.child("isFavourite").getValue(Boolean::class.java) ?: false
+            if (!isFavourite) return@mapNotNull null
+            val id = child.key ?: return@mapNotNull null
+            val title = child.child("title").getValue(String::class.java) ?: return@mapNotNull null
+            val ingredients = child.child("ingredients").children.map { ing ->
+                IngredientData(
+                    name = ing.child("name").getValue(String::class.java),
+                    quantity = ing.child("quantity").getValue(String::class.java),
+                    unit = ing.child("unit").getValue(String::class.java)
+                )
+            }
+            RecipeData(id = id, title = title, ingredients = ingredients, isFavourite = true)
+        }
+    }
+
+    suspend fun loadSelectedRecipeIds(): Set<String> {
+        val snapshot = database.getReference(VIDEO_HISTORY_KEY).awaitGet()
+        return snapshot.children.mapNotNull { it.key }.toSet()
+    }
+
+    suspend fun uploadVideo(videoBytes: ByteArray, monthOf: String): String {
+        val bucket = StorageClient.getInstance().bucket()
+        val blobName = "$STORAGE_VIDEO_PATH/$monthOf.mp4"
+        val blob = bucket.create(blobName, ByteArrayInputStream(videoBytes), "video/mp4")
+        blob.createAcl(Acl.of(Acl.User.ofAllUsers(), Acl.Role.READER))
+        val downloadUrl = "https://storage.googleapis.com/$storageBucket/$blobName"
+        logger.info("Video uploaded to $downloadUrl")
+        return downloadUrl
+    }
+
+    suspend fun writeRecipeOfTheMonth(record: RecipeOfTheMonthRecord): Unit = suspendCancellableCoroutine { cont ->
+        val ref = database.getReference(RECIPE_OF_THE_MONTH_KEY).push()
+        val data = mapOf(
+            "recipeId" to record.recipeId,
+            "recipeTitle" to record.recipeTitle,
+            "videoUrl" to record.videoUrl,
+            "monthOf" to record.monthOf,
+            "createdAt" to record.createdAt
+        )
+        ref.setValue(data) { error: DatabaseError?, _ ->
+            if (error == null) {
+                logger.info("RecipeOfTheMonth record written: ${ref.key}")
+                cont.resume(Unit)
+            } else {
+                cont.resumeWithException(RuntimeException("writeRecipeOfTheMonth failed: ${error.message}"))
+            }
+        }
+    }
+
+    suspend fun markRecipeSelected(recipeId: String): Unit = suspendCancellableCoroutine { cont ->
+        database.getReference(VIDEO_HISTORY_KEY).child(recipeId).setValue(true) { error: DatabaseError?, _ ->
+            if (error == null) {
+                cont.resume(Unit)
+            } else {
+                cont.resumeWithException(RuntimeException("markRecipeSelected failed: ${error.message}"))
+            }
+        }
+    }
+
+    suspend fun updateRecipeVideoUrl(recipeId: String, videoUrl: String): Unit =
+        suspendCancellableCoroutine { cont ->
+            database.getReference(RECIPES_KEY).child(recipeId).child("videoUrl")
+                .setValue(videoUrl) { error: DatabaseError?, _ ->
+                    if (error == null) {
+                        logger.info("Updated videoUrl on recipe $recipeId")
+                        cont.resume(Unit)
+                    } else {
+                        cont.resumeWithException(RuntimeException("updateRecipeVideoUrl failed: ${error.message}"))
+                    }
+                }
+        }
+
+    private suspend fun DatabaseReference.awaitGet(): DataSnapshot = suspendCancellableCoroutine { cont ->
+        addListenerForSingleValueEvent(object : ValueEventListener {
+            override fun onDataChange(snapshot: DataSnapshot) = cont.resume(snapshot)
+            override fun onCancelled(error: DatabaseError) =
+                cont.resumeWithException(RuntimeException("Firebase read cancelled: ${error.message}"))
+        })
+    }
+}

--- a/backend/rotw-job/src/main/kotlin/com/formulae/chef/rotw/service/GeminiPromptBuilder.kt
+++ b/backend/rotw-job/src/main/kotlin/com/formulae/chef/rotw/service/GeminiPromptBuilder.kt
@@ -1,0 +1,28 @@
+package com.formulae.chef.rotw.service
+
+import com.formulae.chef.rotw.model.RecipeData
+
+/**
+ * Builds a Veo 2 prompt from a recipe's data.
+ * Pure function — no external dependencies, fully unit-testable.
+ */
+class GeminiPromptBuilder {
+
+    fun buildPrompt(recipe: RecipeData): String {
+        val topIngredients = recipe.ingredients
+            .mapNotNull { it.name?.takeIf { name -> name.isNotBlank() } }
+            .take(3)
+            .joinToString(", ")
+            .ifEmpty { "fresh ingredients" }
+
+        return buildString {
+            append("Cinematic close-up food video of ${recipe.title}. ")
+            append("Key ingredients: $topIngredients. ")
+            append("Professional food photography lighting, warm tones. ")
+            append("Starts with fresh raw ingredients on a wooden cutting board, ")
+            append("shows cooking action on a modern stovetop, ")
+            append("ends with a beautifully plated serving of ${recipe.title} on an elegant dish with steam rising. ")
+            append("No text overlays, no human hands visible, 16:9 aspect ratio, 4K quality.")
+        }
+    }
+}

--- a/backend/rotw-job/src/main/kotlin/com/formulae/chef/rotw/service/VeoClient.kt
+++ b/backend/rotw-job/src/main/kotlin/com/formulae/chef/rotw/service/VeoClient.kt
@@ -1,0 +1,126 @@
+package com.formulae.chef.rotw.service
+
+import com.google.auth.oauth2.GoogleCredentials
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.request.headers
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import java.util.Base64
+import kotlinx.coroutines.delay
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger(VeoClient::class.java)
+
+private const val POLL_INTERVAL_MS = 30_000L
+private const val MAX_POLL_ATTEMPTS = 20
+
+/**
+ * Calls the Vertex AI Veo 2 API to generate a short food video.
+ *
+ * Endpoint: predictLongRunning → returns an LRO name → poll until done.
+ * Video is returned as base64-encoded MP4 bytes.
+ *
+ * Required env vars: GCP_PROJECT_ID, GCP_LOCATION (default: us-central1)
+ */
+class VeoClient(
+    private val projectId: String = System.getenv("GCP_PROJECT_ID")
+        ?: error("GCP_PROJECT_ID env var not set"),
+    private val location: String = System.getenv("GCP_LOCATION") ?: "us-central1",
+    private val modelId: String = "veo-002"
+) {
+    private val httpClient = HttpClient(CIO) {
+        install(ContentNegotiation) {
+            json(Json { ignoreUnknownKeys = true })
+        }
+    }
+
+    private fun accessToken(): String {
+        val credentials = GoogleCredentials.getApplicationDefault()
+            .createScoped(listOf("https://www.googleapis.com/auth/cloud-platform"))
+        credentials.refreshIfExpired()
+        return credentials.accessToken.tokenValue
+    }
+
+    suspend fun generateVideo(prompt: String, durationSeconds: Int = 15): ByteArray {
+        val token = accessToken()
+        val baseUrl = "https://$location-aiplatform.googleapis.com/v1"
+        val predictUrl =
+            "$baseUrl/projects/$projectId/locations/$location/publishers/google/models/$modelId:predictLongRunning"
+
+        // JsonPrimitive.toString() produces a properly JSON-escaped quoted string
+        val escapedPrompt = kotlinx.serialization.json.JsonPrimitive(prompt).toString()
+        val requestBody = """
+            {
+              "instances": [{ "prompt": $escapedPrompt }],
+              "parameters": {
+                "durationSeconds": $durationSeconds,
+                "aspectRatio": "16:9",
+                "sampleCount": 1,
+                "enhancePrompt": true
+              }
+            }
+        """.trimIndent()
+
+        logger.info("Submitting Veo 2 generation request for prompt: ${prompt.take(80)}...")
+
+        val lroResponse: JsonObject = httpClient.post(predictUrl) {
+            contentType(ContentType.Application.Json)
+            headers { append("Authorization", "Bearer $token") }
+            setBody(requestBody)
+        }.body()
+
+        val operationName = lroResponse["name"]?.jsonPrimitive?.content
+            ?: error("No operation name returned from Veo 2 API")
+
+        logger.info("Veo 2 LRO started: $operationName")
+
+        return pollForCompletion(operationName, "$baseUrl/$operationName", token)
+    }
+
+    private suspend fun pollForCompletion(
+        operationName: String,
+        operationUrl: String,
+        initialToken: String
+    ): ByteArray {
+        repeat(MAX_POLL_ATTEMPTS) { attempt ->
+            delay(POLL_INTERVAL_MS)
+            val token = accessToken()
+            val status: JsonObject = httpClient.get(operationUrl) {
+                headers { append("Authorization", "Bearer $token") }
+            }.body()
+
+            val done = status["done"]?.jsonPrimitive?.boolean ?: false
+            if (done) {
+                logger.info("Veo 2 generation complete after ${attempt + 1} polls")
+                val videoBase64 = status["response"]
+                    ?.jsonObject?.get("videos")
+                    ?.jsonArray?.firstOrNull()
+                    ?.jsonObject?.get("bytesBase64Encoded")
+                    ?.jsonPrimitive?.content
+                    ?: error("No video bytes in Veo 2 response")
+                return Base64.getDecoder().decode(videoBase64)
+            }
+
+            val error = status["error"]
+            if (error != null) {
+                error("Veo 2 operation failed: $error")
+            }
+
+            logger.info("Veo 2 still processing (attempt ${attempt + 1}/$MAX_POLL_ATTEMPTS)...")
+        }
+        error("Veo 2 generation timed out after $MAX_POLL_ATTEMPTS poll attempts")
+    }
+}

--- a/backend/rotw-job/src/main/kotlin/com/formulae/chef/rotw/service/VeoClient.kt
+++ b/backend/rotw-job/src/main/kotlin/com/formulae/chef/rotw/service/VeoClient.kt
@@ -38,7 +38,8 @@ private const val MAX_POLL_ATTEMPTS = 20
 class VeoClient(
     private val projectId: String = System.getenv("GCP_PROJECT_ID")
         ?: error("GCP_PROJECT_ID env var not set"),
-    private val location: String = System.getenv("GCP_LOCATION") ?: "us-central1",
+    private val location: String = System.getenv("GCP_LOCATION")
+        ?: error("GCP_LOCATION env var not set"),
     private val modelId: String = "veo-002"
 ) {
     private val httpClient = HttpClient(CIO) {

--- a/backend/rotw-job/src/test/kotlin/com/formulae/chef/rotw/GeminiPromptBuilderTest.kt
+++ b/backend/rotw-job/src/test/kotlin/com/formulae/chef/rotw/GeminiPromptBuilderTest.kt
@@ -1,0 +1,93 @@
+package com.formulae.chef.rotw
+
+import com.formulae.chef.rotw.model.IngredientData
+import com.formulae.chef.rotw.model.RecipeData
+import com.formulae.chef.rotw.service.GeminiPromptBuilder
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GeminiPromptBuilderTest {
+
+    private val builder = GeminiPromptBuilder()
+
+    @Test
+    fun `prompt contains recipe title`() {
+        val recipe = RecipeData(id = "r1", title = "West African Peanut Stew")
+
+        val prompt = builder.buildPrompt(recipe)
+
+        assertContains(prompt, "West African Peanut Stew")
+    }
+
+    @Test
+    fun `prompt contains top 3 ingredients`() {
+        val recipe = RecipeData(
+            id = "r1",
+            title = "Pasta Carbonara",
+            ingredients = listOf(
+                IngredientData(name = "spaghetti"),
+                IngredientData(name = "pancetta"),
+                IngredientData(name = "eggs"),
+                IngredientData(name = "Parmesan cheese"),
+                IngredientData(name = "black pepper")
+            )
+        )
+
+        val prompt = builder.buildPrompt(recipe)
+
+        assertContains(prompt, "spaghetti")
+        assertContains(prompt, "pancetta")
+        assertContains(prompt, "eggs")
+        assertFalse(prompt.contains("Parmesan cheese"), "Should only include top 3 ingredients")
+    }
+
+    @Test
+    fun `prompt handles recipe with no ingredients`() {
+        val recipe = RecipeData(id = "r1", title = "Mystery Dish", ingredients = emptyList())
+
+        val prompt = builder.buildPrompt(recipe)
+
+        assertContains(prompt, "Mystery Dish")
+        assertContains(prompt, "fresh ingredients")
+    }
+
+    @Test
+    fun `prompt handles ingredients with null names`() {
+        val recipe = RecipeData(
+            id = "r1",
+            title = "Simple Salad",
+            ingredients = listOf(
+                IngredientData(name = null),
+                IngredientData(name = "lettuce"),
+                IngredientData(name = "tomatoes")
+            )
+        )
+
+        val prompt = builder.buildPrompt(recipe)
+
+        assertContains(prompt, "lettuce")
+        assertContains(prompt, "tomatoes")
+    }
+
+    @Test
+    fun `prompt includes cinematic and food photography cues`() {
+        val recipe = RecipeData(id = "r1", title = "Any Dish")
+
+        val prompt = builder.buildPrompt(recipe)
+
+        assertTrue(prompt.contains("cinematic", ignoreCase = true) || prompt.contains("Cinematic"))
+        assertTrue(prompt.contains("16:9"))
+    }
+
+    @Test
+    fun `prompt specifies no text overlays and no hands`() {
+        val recipe = RecipeData(id = "r1", title = "Any Dish")
+
+        val prompt = builder.buildPrompt(recipe)
+
+        assertContains(prompt, "No text")
+        assertContains(prompt, "no human hands")
+    }
+}

--- a/backend/rotw-job/src/test/kotlin/com/formulae/chef/rotw/RecipeSelectorTest.kt
+++ b/backend/rotw-job/src/test/kotlin/com/formulae/chef/rotw/RecipeSelectorTest.kt
@@ -1,0 +1,86 @@
+package com.formulae.chef.rotw
+
+import com.formulae.chef.rotw.job.selectRecipe
+import com.formulae.chef.rotw.model.RecipeData
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class RecipeSelectorTest {
+
+    private val stew = RecipeData(id = "r1", title = "Peanut Stew", isFavourite = true)
+    private val pasta = RecipeData(id = "r2", title = "Pasta Carbonara", isFavourite = true)
+    private val risotto = RecipeData(id = "r3", title = "Mushroom Risotto", isFavourite = true)
+
+    @Test
+    fun `returns null when no favourites available`() {
+        val result = selectRecipe(emptyList(), emptySet())
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `returns null when all favourites already selected`() {
+        val favourites = listOf(stew, pasta)
+        val alreadySelected = setOf("r1", "r2")
+
+        val result = selectRecipe(favourites, alreadySelected)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `returns the only eligible recipe`() {
+        val favourites = listOf(stew, pasta)
+        val alreadySelected = setOf("r1")
+
+        val result = selectRecipe(favourites, alreadySelected)
+
+        assertNotNull(result)
+        assertEquals("r2", result.id)
+        assertEquals("Pasta Carbonara", result.title)
+    }
+
+    @Test
+    fun `selects only from unselected recipes`() {
+        val favourites = listOf(stew, pasta, risotto)
+        val alreadySelected = setOf("r1", "r3")
+
+        val result = selectRecipe(favourites, alreadySelected)
+
+        assertNotNull(result)
+        assertEquals("r2", result.id)
+    }
+
+    @Test
+    fun `returns a recipe when none have been selected yet`() {
+        val favourites = listOf(stew, pasta, risotto)
+
+        val result = selectRecipe(favourites, emptySet())
+
+        assertNotNull(result)
+        assertTrue(result.id in setOf("r1", "r2", "r3"))
+    }
+
+    @Test
+    fun `does not select recipe whose id is in alreadySelected`() {
+        val favourites = listOf(stew)
+        val alreadySelected = setOf("r1")
+
+        val result = selectRecipe(favourites, alreadySelected)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `selection is random across multiple eligible recipes`() {
+        val favourites = (1..20).map { RecipeData(id = "r$it", title = "Recipe $it", isFavourite = true) }
+        val alreadySelected = emptySet<String>()
+
+        val selectedIds = (1..100).mapNotNull { selectRecipe(favourites, alreadySelected)?.id }.toSet()
+
+        assertTrue(selectedIds.size > 1, "Expected random selection to produce multiple different IDs over 100 runs")
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,9 +3,11 @@ import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 plugins {
     id("com.android.application") version "8.13.2" apply false
     id("org.jetbrains.kotlin.android") version "2.1.20" apply false
+    id("org.jetbrains.kotlin.jvm") version "2.1.20" apply false
     id("com.google.gms.google-services") version "4.4.4" apply false
     id("com.github.ben-manes.versions") version "0.51.0" apply true
     id("org.jetbrains.kotlin.plugin.compose") version "2.1.20" apply false
+    id("com.google.cloud.tools.jib") version "3.4.4" apply false
 }
 
 allprojects {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,5 +7,6 @@ pluginManagement {
 }
 
 include(
-        ":vertexai:app"
+        ":vertexai:app",
+        ":backend:rotw-job"
 )

--- a/vertexai/app/build.gradle.kts
+++ b/vertexai/app/build.gradle.kts
@@ -122,6 +122,7 @@ dependencies {
     implementation("io.opentelemetry:opentelemetry-exporter-otlp:1.52.0")
 
     implementation("androidx.media3:media3-exoplayer:1.4.1")
+    implementation("androidx.media3:media3-ui:1.4.1")
 
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/AppNavigation.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/AppNavigation.kt
@@ -1,6 +1,9 @@
 package com.formulae.chef
 
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -9,8 +12,10 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.formulae.chef.feature.chat.ui.ChatRoute
 import com.formulae.chef.feature.collection.ui.CollectionRoute
+import com.formulae.chef.feature.collection.ui.DetailRoute
 import com.formulae.chef.feature.collection.ui.RecipeSource
 import com.formulae.chef.feature.home.HomeScreenViewModel
+import com.formulae.chef.feature.model.Recipe
 import com.formulae.chef.feature.useraccount.ui.SignInRoute
 import com.formulae.chef.services.authentication.UserSessionService
 import com.formulae.chef.services.persistence.RecipeListRepository
@@ -34,11 +39,13 @@ fun AppNavigation(
             HomeScreen(
                 viewModel = homeViewModel,
                 userSessionService = userSessionService,
+                recipeRepository = recipeRepository,
                 onNavigateToChat = { navController.navigate("chat") },
                 onNavigateToCollection = { navController.navigate("collection") },
                 onNavigateToCommunity = {
                     navController.navigate("collection?tab=${RecipeSource.ALL_RECIPES.name}")
                 },
+                onNavigateToRecipe = { recipeId -> navController.navigate("recipeDetail/$recipeId") },
                 onSignOut = {
                     userSessionService.signOut()
                     navController.navigate("signIn") {
@@ -76,6 +83,21 @@ fun AppNavigation(
                 userSessionService = userSessionService,
                 initialRecipeSource = tab
             )
+        }
+        composable("recipeDetail/{recipeId}") { backStackEntry ->
+            val recipeId = backStackEntry.arguments?.getString("recipeId") ?: ""
+            val recipe by produceState<Recipe?>(initialValue = null, key1 = recipeId) {
+                value = recipeRepository.getRecipeById(recipeId)
+            }
+            val loadedRecipe = recipe
+            if (loadedRecipe == null) {
+                CircularProgressIndicator()
+            } else {
+                DetailRoute(
+                    recipe = loadedRecipe,
+                    onBack = { navController.popBackStack() }
+                )
+            }
         }
         composable("signIn") {
             SignInRoute(userSessionService, navController)

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/HomeScreen.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/HomeScreen.kt
@@ -3,8 +3,10 @@ package com.formulae.chef
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
@@ -12,6 +14,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Chat
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -37,17 +41,22 @@ import com.formulae.chef.feature.chat.OverlayChatViewModel
 import com.formulae.chef.feature.chat.ui.ChefOverlay
 import com.formulae.chef.feature.collection.ui.DetailRoute
 import com.formulae.chef.feature.collection.ui.RecipeItem
+import com.formulae.chef.feature.collection.ui.RecipeVideoSection
 import com.formulae.chef.feature.home.HomeScreenViewModel
+import com.formulae.chef.feature.model.RecipeOfTheMonth
 import com.formulae.chef.services.authentication.UserSessionService
+import com.formulae.chef.services.persistence.RecipeRepository
 import com.google.firebase.auth.UserInfo
 
 @Composable
 fun HomeScreen(
     viewModel: HomeScreenViewModel,
     userSessionService: UserSessionService,
+    recipeRepository: RecipeRepository,
     onNavigateToChat: () -> Unit = {},
     onNavigateToCollection: () -> Unit = {},
     onNavigateToCommunity: () -> Unit = {},
+    onNavigateToRecipe: (String) -> Unit = {},
     onSignOut: () -> Unit = {}
 ) {
     var isLoading by remember { mutableStateOf(true) }
@@ -93,8 +102,10 @@ fun HomeScreen(
                 onNavigateToChat = onNavigateToChat,
                 onNavigateToCollection = onNavigateToCollection,
                 onNavigateToCommunity = onNavigateToCommunity,
+                onNavigateToRecipe = onNavigateToRecipe,
                 onSignOut = onSignOut,
-                signedIn = !userSessionService.anonymousSession && currentUser != null
+                signedIn = !userSessionService.anonymousSession && currentUser != null,
+                recipeRepository = recipeRepository
             )
         }
     }
@@ -106,8 +117,10 @@ private fun HomeScreenContent(
     onNavigateToChat: () -> Unit,
     onNavigateToCollection: () -> Unit,
     onNavigateToCommunity: () -> Unit,
+    onNavigateToRecipe: (String) -> Unit,
     onSignOut: () -> Unit,
-    signedIn: Boolean
+    signedIn: Boolean,
+    recipeRepository: RecipeRepository
 ) {
     val overlayViewModel: OverlayChatViewModel = viewModel(factory = OverlayChatViewModelFactory)
     var showChefOverlay by remember { mutableStateOf(false) }
@@ -115,6 +128,9 @@ private fun HomeScreenContent(
     val userRecipes by viewModel.userRecipes.collectAsState()
     val communityRecipes by viewModel.communityRecipes.collectAsState()
     val isLoadingRecipes by viewModel.isLoading.collectAsState()
+    val latestRotw by produceState<RecipeOfTheMonth?>(initialValue = null) {
+        value = recipeRepository.getLatestRecipeOfTheMonth()
+    }
 
     Scaffold(
         floatingActionButton = {
@@ -211,6 +227,17 @@ private fun HomeScreenContent(
                     }
                 }
 
+                latestRotw?.takeIf { it.videoUrl.isNotEmpty() }?.let { rotw ->
+                    item {
+                        Spacer(modifier = Modifier.height(16.dp))
+                        RecipeOfTheMonthCard(
+                            rotw = rotw,
+                            onViewRecipe = { onNavigateToRecipe(rotw.recipeId) },
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                }
+
                 item {
                     Column(
                         modifier = Modifier
@@ -242,6 +269,43 @@ private fun HomeScreenContent(
                 recipe = null,
                 onDismiss = { showChefOverlay = false }
             )
+        }
+    }
+}
+
+@Composable
+private fun RecipeOfTheMonthCard(
+    rotw: RecipeOfTheMonth,
+    onViewRecipe: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier,
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "Recipe of the Month",
+                style = MaterialTheme.typography.titleMedium
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = rotw.recipeTitle,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            RecipeVideoSection(
+                videoUrl = rotw.videoUrl,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Button(
+                onClick = onViewRecipe,
+                modifier = Modifier.align(Alignment.End)
+            ) {
+                Text("View Recipe →")
+            }
         }
     }
 }

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/DetailScreen.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/collection/ui/DetailScreen.kt
@@ -20,30 +20,38 @@ import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -53,6 +61,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.media3.common.MediaItem
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.PlayerView
 import coil.compose.rememberAsyncImagePainter
 import com.formulae.chef.BuildConfig
 import com.formulae.chef.feature.collection.parseTips
@@ -198,6 +210,12 @@ private fun CreateDetailScreen(
         Spacer(modifier = Modifier.height(8.dp))
 
         Text(text = recipe.summary.replace("\\n", "\n"), style = MaterialTheme.typography.bodyMedium)
+
+        recipe.videoUrl?.takeIf { it.isNotEmpty() }?.let { videoUrl ->
+            Spacer(modifier = Modifier.height(12.dp))
+            RecipeVideoSection(videoUrl = videoUrl)
+        }
+
         Spacer(modifier = Modifier.height(8.dp))
 
         // Tab toggle — shown in both normal and cooking mode
@@ -408,4 +426,65 @@ private fun TipsSection(tipsAndTricks: String) {
         )
     }
     Spacer(modifier = Modifier.height(8.dp))
+}
+
+@Composable
+internal fun RecipeVideoSection(videoUrl: String, modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    var isPlaying by remember { mutableStateOf(false) }
+    val player = remember {
+        ExoPlayer.Builder(context).build().apply {
+            setMediaItem(MediaItem.fromUri(videoUrl))
+            prepare()
+        }
+    }
+    DisposableEffect(Unit) {
+        onDispose { player.release() }
+    }
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = "🎬 Recipe of the Month",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(bottom = 4.dp)
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(16f / 9f)
+                .clip(RoundedCornerShape(8.dp))
+        ) {
+            AndroidView(
+                factory = { ctx ->
+                    PlayerView(ctx).apply {
+                        this.player = player
+                        useController = true
+                    }
+                },
+                modifier = Modifier.fillMaxSize()
+            )
+            if (!isPlaying) {
+                Surface(
+                    shape = CircleShape,
+                    color = MaterialTheme.colorScheme.surface.copy(alpha = 0.8f),
+                    modifier = Modifier
+                        .size(56.dp)
+                        .align(Alignment.Center)
+                ) {
+                    IconButton(onClick = {
+                        player.play()
+                        isPlaying = true
+                    }) {
+                        Icon(
+                            imageVector = Icons.Default.PlayArrow,
+                            contentDescription = "Play recipe video",
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(32.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
 }

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/model/Recipe.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/model/Recipe.kt
@@ -17,6 +17,7 @@ data class Recipe(
     var tipsAndTricks: String? = null,
 
     var imageUrl: String? = null,
+    var videoUrl: String? = null,
     var updatedAt: String = "",
     @get:PropertyName("isFavourite")
     @set:PropertyName("isFavourite")
@@ -39,6 +40,7 @@ data class Recipe(
         instructions: List<String> = this.instructions,
         tipsAndTricks: String? = this.tipsAndTricks,
         imageUrl: String? = this.imageUrl,
+        videoUrl: String? = this.videoUrl,
         updatedAt: String = this.updatedAt,
         isFavourite: Boolean = this.isFavourite,
         copyId: String? = this.copyId,
@@ -58,6 +60,7 @@ data class Recipe(
             instructions,
             tipsAndTricks,
             imageUrl,
+            videoUrl,
             updatedAt,
             isFavourite,
             copyId,

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/model/RecipeOfTheMonth.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/model/RecipeOfTheMonth.kt
@@ -1,0 +1,10 @@
+package com.formulae.chef.feature.model
+
+data class RecipeOfTheMonth(
+    var id: String? = null,
+    var recipeId: String = "",
+    var recipeTitle: String = "",
+    var videoUrl: String = "",
+    var monthOf: String = "",
+    var createdAt: String = ""
+)

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/services/persistence/RecipeRepository.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/services/persistence/RecipeRepository.kt
@@ -1,6 +1,7 @@
 package com.formulae.chef.services.persistence
 
 import com.formulae.chef.feature.model.Recipe
+import com.formulae.chef.feature.model.RecipeOfTheMonth
 
 interface RecipeRepository {
     fun saveRecipe(recipe: Recipe)
@@ -8,4 +9,6 @@ interface RecipeRepository {
     suspend fun loadAllRecipes(): List<Recipe>
     fun removeRecipe(recipeId: String)
     fun removeRecipeUid(recipeId: String)
+    suspend fun getRecipeById(recipeId: String): Recipe?
+    suspend fun getLatestRecipeOfTheMonth(): RecipeOfTheMonth?
 }

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/services/persistence/RecipeRepositoryImpl.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/services/persistence/RecipeRepositoryImpl.kt
@@ -79,7 +79,6 @@ class RecipeRepositoryImpl(
 
     override suspend fun getLatestRecipeOfTheMonth(): RecipeOfTheMonth? {
         return database.getReference(RECIPE_OF_THE_MONTH_KEY)
-            .orderByChild("createdAt")
             .limitToLast(1)
             .get()
             .await()

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/services/persistence/RecipeRepositoryImpl.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/services/persistence/RecipeRepositoryImpl.kt
@@ -2,10 +2,12 @@ package com.formulae.chef.services.persistence
 
 import android.util.Log
 import com.formulae.chef.feature.model.Recipe
+import com.formulae.chef.feature.model.RecipeOfTheMonth
 import com.google.firebase.database.FirebaseDatabase
 import kotlinx.coroutines.tasks.await
 
 private const val RECIPES_KEY = "recipes"
+private const val RECIPE_OF_THE_MONTH_KEY = "recipe_of_the_month"
 
 class RecipeRepositoryImpl(
     private val database: FirebaseDatabase = FirebaseInstance.database
@@ -67,5 +69,22 @@ class RecipeRepositoryImpl(
             .addOnFailureListener { e ->
                 Log.e("FirebaseDB", "Error updating recipe", e)
             }
+    }
+
+    override suspend fun getRecipeById(recipeId: String): Recipe? {
+        val snapshot = recipesRef.child(recipeId).get().await()
+        return snapshot.getValue(Recipe::class.java)
+            ?.copy(isFavourite = snapshot.child("isFavourite").getValue(Boolean::class.java) ?: false)
+    }
+
+    override suspend fun getLatestRecipeOfTheMonth(): RecipeOfTheMonth? {
+        return database.getReference(RECIPE_OF_THE_MONTH_KEY)
+            .orderByChild("createdAt")
+            .limitToLast(1)
+            .get()
+            .await()
+            .children
+            .firstOrNull()
+            ?.getValue(RecipeOfTheMonth::class.java)
     }
 }

--- a/vertexai/app/src/test/kotlin/com/formulae/chef/feature/collection/CollectionViewModelTest.kt
+++ b/vertexai/app/src/test/kotlin/com/formulae/chef/feature/collection/CollectionViewModelTest.kt
@@ -745,6 +745,14 @@ private class FakeRecipeRepository(
     override fun removeRecipeUid(recipeId: String) {
         removedUidRecipeIds.add(recipeId)
     }
+
+    override suspend fun getRecipeById(recipeId: String): Recipe? {
+        return recipes.find { it.id == recipeId }
+    }
+
+    override suspend fun getLatestRecipeOfTheMonth(): com.formulae.chef.feature.model.RecipeOfTheMonth? {
+        return null
+    }
 }
 
 private class FakeRecipeListRepository(

--- a/vertexai/app/src/test/kotlin/com/formulae/chef/feature/home/HomeScreenViewModelTest.kt
+++ b/vertexai/app/src/test/kotlin/com/formulae/chef/feature/home/HomeScreenViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.formulae.chef.feature.home
 
 import com.formulae.chef.feature.model.Recipe
+import com.formulae.chef.feature.model.RecipeOfTheMonth
 import com.formulae.chef.services.persistence.RecipeRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -164,4 +165,6 @@ private class FakeRecipeRepository(
     override suspend fun loadAllRecipes(): List<Recipe> = recipes
     override fun removeRecipe(recipeId: String) = Unit
     override fun removeRecipeUid(recipeId: String) = Unit
+    override suspend fun getRecipeById(recipeId: String): Recipe? = recipes.find { it.id == recipeId }
+    override suspend fun getLatestRecipeOfTheMonth(): RecipeOfTheMonth? = null
 }

--- a/vertexai/app/src/test/kotlin/com/formulae/chef/feature/model/RecipeOfTheMonthTest.kt
+++ b/vertexai/app/src/test/kotlin/com/formulae/chef/feature/model/RecipeOfTheMonthTest.kt
@@ -1,0 +1,55 @@
+package com.formulae.chef.feature.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RecipeOfTheMonthTest {
+
+    @Test
+    fun `default RecipeOfTheMonth has expected default values`() {
+        val rotw = RecipeOfTheMonth()
+
+        assertNull(rotw.id)
+        assertEquals("", rotw.recipeId)
+        assertEquals("", rotw.recipeTitle)
+        assertEquals("", rotw.videoUrl)
+        assertEquals("", rotw.monthOf)
+        assertEquals("", rotw.createdAt)
+    }
+
+    @Test
+    fun `RecipeOfTheMonth with all fields populated`() {
+        val rotw = RecipeOfTheMonth(
+            id = "push-id-1",
+            recipeId = "recipe-abc",
+            recipeTitle = "West African Peanut Stew",
+            videoUrl = "https://storage.googleapis.com/bucket/videos/rotw/2026-04.mp4",
+            monthOf = "2026-04",
+            createdAt = "2026-04-06T22:00:00Z"
+        )
+
+        assertEquals("push-id-1", rotw.id)
+        assertEquals("recipe-abc", rotw.recipeId)
+        assertEquals("West African Peanut Stew", rotw.recipeTitle)
+        assertEquals("https://storage.googleapis.com/bucket/videos/rotw/2026-04.mp4", rotw.videoUrl)
+        assertEquals("2026-04", rotw.monthOf)
+        assertEquals("2026-04-06T22:00:00Z", rotw.createdAt)
+    }
+
+    @Test
+    fun `data class equality works correctly`() {
+        val a = RecipeOfTheMonth(recipeId = "abc", monthOf = "2026-04")
+        val b = RecipeOfTheMonth(recipeId = "abc", monthOf = "2026-04")
+
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `videoUrl empty string indicates no video available`() {
+        val rotw = RecipeOfTheMonth(recipeId = "abc", videoUrl = "")
+
+        assertTrue(rotw.videoUrl.isEmpty())
+    }
+}

--- a/vertexai/app/src/test/kotlin/com/formulae/chef/feature/model/RecipeTest.kt
+++ b/vertexai/app/src/test/kotlin/com/formulae/chef/feature/model/RecipeTest.kt
@@ -27,6 +27,7 @@ class RecipeTest {
         assertTrue(recipe.instructions.isEmpty())
         assertNull(recipe.tipsAndTricks)
         assertNull(recipe.imageUrl)
+        assertNull(recipe.videoUrl)
         assertEquals("", recipe.updatedAt)
         assertFalse(recipe.isFavourite)
         assertNull(recipe.copyId)
@@ -59,6 +60,7 @@ class RecipeTest {
             instructions = instructions,
             tipsAndTricks = "Use room temperature butter",
             imageUrl = "https://example.com/cake.jpg",
+            videoUrl = "https://storage.googleapis.com/bucket/videos/rotw/2026-04.mp4",
             updatedAt = "2026-01-01T00:00:00Z",
             isFavourite = true,
             copyId = "copy-1",
@@ -78,6 +80,7 @@ class RecipeTest {
         assertEquals(2, recipe.instructions.size)
         assertEquals("Use room temperature butter", recipe.tipsAndTricks)
         assertEquals("https://example.com/cake.jpg", recipe.imageUrl)
+        assertEquals("https://storage.googleapis.com/bucket/videos/rotw/2026-04.mp4", recipe.videoUrl)
         assertEquals("2026-01-01T00:00:00Z", recipe.updatedAt)
         assertTrue(recipe.isFavourite)
         assertEquals("copy-1", recipe.copyId)
@@ -98,7 +101,8 @@ class RecipeTest {
         val copy = original.copyOf(
             title = "Modified Title",
             isFavourite = true,
-            imageUrl = "https://example.com/new.jpg"
+            imageUrl = "https://example.com/new.jpg",
+            videoUrl = "https://storage.googleapis.com/bucket/videos/rotw/2026-04.mp4"
         )
 
         assertEquals("1", copy.id)
@@ -107,7 +111,29 @@ class RecipeTest {
         assertEquals("Original summary", copy.summary)
         assertTrue(copy.isFavourite)
         assertEquals("https://example.com/new.jpg", copy.imageUrl)
+        assertEquals("https://storage.googleapis.com/bucket/videos/rotw/2026-04.mp4", copy.videoUrl)
         assertEquals(listOf("chicken", "korean"), copy.tags)
+    }
+
+    @Test
+    fun `copyOf preserves videoUrl when not overridden`() {
+        val original = Recipe(
+            id = "1",
+            videoUrl = "https://storage.googleapis.com/bucket/videos/rotw/2026-04.mp4"
+        )
+
+        val copy = original.copyOf(title = "New Title")
+
+        assertEquals("https://storage.googleapis.com/bucket/videos/rotw/2026-04.mp4", copy.videoUrl)
+    }
+
+    @Test
+    fun `copyOf overrides videoUrl when provided`() {
+        val original = Recipe(id = "1", videoUrl = "https://example.com/old.mp4")
+
+        val copy = original.copyOf(videoUrl = "https://example.com/new.mp4")
+
+        assertEquals("https://example.com/new.mp4", copy.videoUrl)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **Android app:** surfaces Recipe of the Month videos — tap-to-play `ExoPlayer` player in recipe detail (below summary) and a `RecipeOfTheMonthCard` on the home dashboard with a deep-link to recipe detail
- **New `:backend:rotw-job` module:** plain JVM Kotlin Cloud Run Job that selects a random favourite recipe, generates a 15-second cinematic food video via Veo 2 (Vertex AI), uploads to Firebase Storage and writes to RTDB
- **Never-repeat guarantee:** `video_generation_history` RTDB node is written at generation time and never deleted — same recipe is never featured twice even if `recipe_of_the_month` entries are cleaned up
- **Schema:** new `recipe_of_the_month` and `video_generation_history` root nodes; optional `videoUrl` field on `Recipe`; all documented in `.ai/database-schema.md`

## Architecture

```
Cloud Scheduler (0 22 1-7 * 0)
  → Cloud Run Job (:backend:rotw-job)
      1. Load isFavourite=true recipes from RTDB
      2. Filter out video_generation_history entries
      3. Pick random recipe
      4. GeminiPromptBuilder → Veo 2 prompt
      5. VeoClient → Vertex AI Veo 2 → 15s MP4 via LRO polling
      6. Upload to Firebase Storage: videos/rotw/{YYYY-MM}.mp4
      7. Write recipe_of_the_month/{pushId}
      8. Write recipes/{id}/videoUrl
      9. Write video_generation_history/{id} = true
```

## Setup notes for reviewers

Gitignored files needed to build/run locally:
- `local.properties` — `firebaseDbUrl`, `phoenixApiKey`, `gcpTtsApiKey`
- `vertexai/app/google-services.json`
- `vertexai/app/src/main/assets/chat_system_prompt.txt`

Backend env vars (for Cloud Run deployment — not needed for unit tests):
- `GOOGLE_APPLICATION_CREDENTIALS` — service account JSON path
- `FIREBASE_DB_URL` — Firebase RTDB URL
- `FIREBASE_STORAGE_BUCKET` — e.g. `project-id.appspot.com`
- `GCP_PROJECT_ID` — GCP project ID
- `GCP_LOCATION` — Vertex AI region (default: `us-central1`)

**Note:** Veo 2 model name may need verification against current Vertex AI docs — currently set to `veo-002` in `VeoClient.kt`.

## Test plan

- [x] `./gradlew ktlintCheck` — passes ✅
- [x] `./gradlew :vertexai:app:assembleDebug` — passes ✅
- [x] `./gradlew :vertexai:app:testDebugUnitTest` — passes (RecipeTest, RecipeOfTheMonthTest, CollectionViewModelTest) ✅
- [x] `./gradlew :backend:rotw-job:test` — passes (RecipeSelectorTest, GeminiPromptBuilderTest) ✅
- [x] Install APK on device; open recipe detail for a recipe with `videoUrl` set → video section visible with "🎬 Recipe of the Month" label and play button
- [x] Tap play → 15s video plays in 16:9 ExoPlayer surface
- [x] Home screen → Recipe of the Month card visible at bottom (requires `recipe_of_the_month` RTDB entry)
- [x] Tap "View Recipe →" → navigates to recipe detail with video
- [x] Back from detail → returns to home screen
- [ ] Backend smoke test: set env vars, run `./gradlew :backend:rotw-job:run`, verify RTDB writes and Storage upload

Closes CHE-29