### PR TITLE
CHE-18: Add AI-generated personalized cooking resources section to dashboard

### DIFF
--- a/vertexai/app/src/main/kotlin/com/formulae/chef/HomeScreen.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/HomeScreen.kt
@@ -1,18 +1,27 @@
 package com.formulae.chef
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Chat
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
@@ -20,11 +29,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.formulae.chef.feature.chat.OverlayChatViewModel
 import com.formulae.chef.feature.chat.ui.ChefOverlay
+import com.formulae.chef.feature.home.HomeUiState
+import com.formulae.chef.feature.home.HomeViewModel
+import com.formulae.chef.feature.model.CookingResource
 import com.formulae.chef.services.authentication.UserSessionService
 import com.google.firebase.auth.UserInfo
 
@@ -55,11 +68,17 @@ fun HomeScreen(
         if (!userSessionService.anonymousSession && currentUser == null) {
             onSignOut()
         }
+        val signedIn = !userSessionService.anonymousSession && currentUser != null
+        val homeViewModel: HomeViewModel = viewModel(
+            factory = HomeViewModelFactory(userSessionService)
+        )
+        val homeUiState by homeViewModel.uiState.collectAsState()
         HomeScreenContent(
-            onNavigateToChat,
-            onNavigateToCollection,
-            onSignOut,
-            !userSessionService.anonymousSession && currentUser != null
+            onNavigateToChat = onNavigateToChat,
+            onNavigateToCollection = onNavigateToCollection,
+            onSignOut = onSignOut,
+            signedIn = signedIn,
+            homeUiState = if (signedIn) homeUiState else HomeUiState()
         )
     }
 }
@@ -69,7 +88,8 @@ private fun HomeScreenContent(
     onNavigateToChat: () -> Unit,
     onNavigateToCollection: () -> Unit,
     onSignOut: () -> Unit,
-    signedIn: Boolean
+    signedIn: Boolean,
+    homeUiState: HomeUiState = HomeUiState()
 ) {
     val overlayViewModel: OverlayChatViewModel = viewModel(factory = OverlayChatViewModelFactory)
     var showChefOverlay by remember { mutableStateOf(false) }
@@ -81,32 +101,63 @@ private fun HomeScreenContent(
             }
         }
     ) { paddingValues ->
-        Column(
+        LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
+                .padding(paddingValues)
         ) {
-            Button(
-                onClick = onNavigateToChat,
-                enabled = signedIn,
-                modifier = Modifier.padding(16.dp)
-            ) {
-                Text(text = "Go to Chat")
-            }
-            Button(
-                onClick = onNavigateToCollection,
-                modifier = Modifier.padding(16.dp)
-            ) {
-                Text(text = "View Collection")
+            item {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 32.dp),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Button(
+                        onClick = onNavigateToChat,
+                        enabled = signedIn,
+                        modifier = Modifier.padding(16.dp)
+                    ) {
+                        Text(text = "Go to Chat")
+                    }
+                    Button(
+                        onClick = onNavigateToCollection,
+                        modifier = Modifier.padding(16.dp)
+                    ) {
+                        Text(text = "View Collection")
+                    }
+                    Button(
+                        onClick = onSignOut,
+                        modifier = Modifier.padding(16.dp)
+                    ) {
+                        Text(text = "Sign out")
+                    }
+                }
             }
 
-            Button(
-                onClick = onSignOut,
-                modifier = Modifier.padding(16.dp)
-            ) {
-                Text(text = "Sign out")
+            if (homeUiState.isLoading) {
+                item {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        horizontalArrangement = Arrangement.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+            } else if (homeUiState.resources.isNotEmpty()) {
+                item {
+                    Text(
+                        text = "Cooking Resources",
+                        style = MaterialTheme.typography.titleLarge,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                    )
+                }
+                items(homeUiState.resources) { resource ->
+                    CookingResourceCard(resource = resource)
+                }
             }
         }
 
@@ -120,6 +171,53 @@ private fun HomeScreenContent(
     }
 }
 
+@Composable
+private fun CookingResourceCard(resource: CookingResource) {
+    val uriHandler = LocalUriHandler.current
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 6.dp)
+            .clickable {
+                if (resource.url.isNotBlank()) {
+                    uriHandler.openUri(resource.url)
+                }
+            }
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    text = resource.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f)
+                )
+                if (resource.type.isNotBlank()) {
+                    SuggestionChip(
+                        onClick = {},
+                        label = { Text(resource.type) }
+                    )
+                }
+            }
+            if (resource.description.isNotBlank()) {
+                Text(
+                    text = resource.description,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
+            }
+            Text(
+                text = resource.url,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
 fun PreviewHomeNavigationScreen() {
@@ -127,6 +225,22 @@ fun PreviewHomeNavigationScreen() {
         onNavigateToChat = {},
         onNavigateToCollection = {},
         onSignOut = {},
-        signedIn = true
+        signedIn = true,
+        homeUiState = HomeUiState(
+            resources = listOf(
+                CookingResource(
+                    title = "Köket.se",
+                    url = "https://koket.se",
+                    type = "website",
+                    description = "Sveriges största matsite med massor av recept."
+                ),
+                CookingResource(
+                    title = "Gordon Ramsay",
+                    url = "https://youtube.com/@gordonramsay",
+                    type = "youtube",
+                    description = "World-class cooking techniques from a Michelin-starred chef."
+                )
+            )
+        )
     )
 }

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/HomeViewModelFactory.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/HomeViewModelFactory.kt
@@ -1,0 +1,43 @@
+package com.formulae.chef
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.CreationExtras
+import com.formulae.chef.feature.home.HomeViewModel
+import com.formulae.chef.services.authentication.UserSessionService
+import com.google.firebase.Firebase
+import com.google.firebase.vertexai.type.content
+import com.google.firebase.vertexai.type.generationConfig
+import com.google.firebase.vertexai.vertexAI
+
+private const val COOKING_RESOURCES_SYSTEM_INSTRUCTIONS =
+    """You are a cooking resource recommender. Given a user locale and their dietary/cooking preference
+summary, return a JSON array of 5-8 recommended cooking websites, YouTube channels, or blogs.
+Each item must have: title (string), url (valid full URL starting with https://), type (one of
+"website", "youtube", "blog", "instagram"), description (one sentence about the resource, in the
+user's locale language if non-English).
+Prioritize resources in the user's locale language and relevant to their stated preferences.
+Return only the JSON array with no wrapper object, markdown, or explanation."""
+
+class HomeViewModelFactory(
+    private val userSessionService: UserSessionService
+) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+        val jsonConfig = generationConfig {
+            temperature = 0.4f
+            maxOutputTokens = 2048
+            topP = 0.95f
+            responseMimeType = "application/json"
+        }
+        val model = Firebase.vertexAI.generativeModel(
+            modelName = "gemini-2.5-flash-lite",
+            generationConfig = jsonConfig,
+            systemInstruction = content { text(COOKING_RESOURCES_SYSTEM_INSTRUCTIONS) }
+        )
+        return HomeViewModel(
+            userSessionService = userSessionService,
+            resourcesGenerativeModel = model
+        ) as T
+    }
+}

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/home/HomeUiState.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/home/HomeUiState.kt
@@ -1,0 +1,8 @@
+package com.formulae.chef.feature.home
+
+import com.formulae.chef.feature.model.CookingResource
+
+data class HomeUiState(
+    val resources: List<CookingResource> = emptyList(),
+    val isLoading: Boolean = false
+)

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/home/HomeViewModel.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/home/HomeViewModel.kt
@@ -1,0 +1,122 @@
+package com.formulae.chef.feature.home
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.formulae.chef.feature.model.CookingResource
+import com.formulae.chef.services.authentication.UserSessionService
+import com.formulae.chef.services.persistence.CachedCookingResources
+import com.formulae.chef.services.persistence.CookingResourcesRepository
+import com.formulae.chef.services.persistence.CookingResourcesRepositoryImpl
+import com.formulae.chef.services.persistence.UserPreferencesRepository
+import com.formulae.chef.services.persistence.UserPreferencesRepositoryImpl
+import com.google.firebase.vertexai.GenerativeModel
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.util.Locale
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+private const val TAG = "HomeViewModel"
+private const val CACHE_MAX_AGE_DAYS = 7L
+
+class HomeViewModel(
+    private val userSessionService: UserSessionService,
+    private val resourcesGenerativeModel: GenerativeModel,
+    private val preferencesRepositoryFactory: (String) -> UserPreferencesRepository = { uid ->
+        UserPreferencesRepositoryImpl(uid)
+    },
+    private val resourcesRepositoryFactory: (String) -> CookingResourcesRepository = { uid ->
+        CookingResourcesRepositoryImpl(uid)
+    }
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(HomeUiState())
+    val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            val user = userSessionService.currentUser.first { it != null }
+            if (user != null) {
+                loadOrGenerateResources(user.uid)
+            }
+        }
+    }
+
+    private suspend fun loadOrGenerateResources(uid: String) {
+        _uiState.value = _uiState.value.copy(isLoading = true)
+        try {
+            val prefsRepo = preferencesRepositoryFactory(uid)
+            val resourcesRepo = resourcesRepositoryFactory(uid)
+
+            val preferences = prefsRepo.loadPreferences()
+            val cached = resourcesRepo.load()
+
+            if (cached != null && !isStale(cached, preferences?.updatedAt)) {
+                Log.d(TAG, "Using cached cooking resources (${cached.resources.size} items)")
+                _uiState.value = HomeUiState(resources = cached.resources, isLoading = false)
+                return
+            }
+
+            Log.d(TAG, "Generating fresh cooking resources via Gemini")
+            val generated = generateResources(preferences?.summary.orEmpty())
+            if (generated.isNotEmpty()) {
+                val newCache = CachedCookingResources(
+                    resources = generated,
+                    updatedAt = ZonedDateTime.now(ZoneOffset.UTC).toString()
+                )
+                resourcesRepo.save(newCache)
+                _uiState.value = HomeUiState(resources = generated, isLoading = false)
+            } else {
+                _uiState.value = HomeUiState(isLoading = false)
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to load/generate cooking resources", e)
+            _uiState.value = HomeUiState(isLoading = false)
+        }
+    }
+
+    private fun isStale(cached: CachedCookingResources, preferencesUpdatedAt: String?): Boolean {
+        if (cached.updatedAt.isBlank()) return true
+        return try {
+            val cacheTime = ZonedDateTime.parse(cached.updatedAt)
+            val maxAge = ZonedDateTime.now(ZoneOffset.UTC).minusDays(CACHE_MAX_AGE_DAYS)
+            if (cacheTime.isBefore(maxAge)) return true
+
+            if (!preferencesUpdatedAt.isNullOrBlank()) {
+                val prefsTime = ZonedDateTime.parse(preferencesUpdatedAt)
+                prefsTime.isAfter(cacheTime)
+            } else {
+                false
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Could not parse timestamps for staleness check, treating as stale", e)
+            true
+        }
+    }
+
+    private suspend fun generateResources(preferencesSummary: String): List<CookingResource> {
+        val locale = Locale.getDefault()
+        val prompt = buildString {
+            append("User locale: ${locale.displayLanguage} (${locale.country})\n")
+            if (preferencesSummary.isNotBlank()) {
+                append("User cooking preferences: $preferencesSummary\n")
+            }
+            append("Recommend 5-8 personalized cooking resources for this user.")
+        }
+        return try {
+            val response = resourcesGenerativeModel.generateContent(prompt)
+            val json = response.text ?: return emptyList()
+            val type = object : TypeToken<List<CookingResource>>() {}.type
+            Gson().fromJson(json, type) ?: emptyList()
+        } catch (e: Exception) {
+            Log.e(TAG, "Gemini resource generation failed", e)
+            emptyList()
+        }
+    }
+}

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/model/CookingResource.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/model/CookingResource.kt
@@ -1,0 +1,8 @@
+package com.formulae.chef.feature.model
+
+data class CookingResource(
+    var title: String = "",
+    var url: String = "",
+    var type: String = "",
+    var description: String = ""
+)

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/services/persistence/CookingResourcesRepository.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/services/persistence/CookingResourcesRepository.kt
@@ -1,0 +1,13 @@
+package com.formulae.chef.services.persistence
+
+import com.formulae.chef.feature.model.CookingResource
+
+data class CachedCookingResources(
+    var resources: List<CookingResource> = emptyList(),
+    var updatedAt: String = ""
+)
+
+interface CookingResourcesRepository {
+    suspend fun load(): CachedCookingResources?
+    suspend fun save(cached: CachedCookingResources)
+}

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/services/persistence/CookingResourcesRepositoryImpl.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/services/persistence/CookingResourcesRepositoryImpl.kt
@@ -1,0 +1,33 @@
+package com.formulae.chef.services.persistence
+
+import android.util.Log
+import com.google.firebase.database.FirebaseDatabase
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.tasks.await
+
+class CookingResourcesRepositoryImpl(
+    private val uid: String,
+    private val database: FirebaseDatabase = FirebaseInstance.database
+) : CookingResourcesRepository {
+    private val ref get() = database.getReference("users/$uid/cooking_resources")
+
+    override suspend fun load(): CachedCookingResources? {
+        return suspendCancellableCoroutine { continuation ->
+            ref.get()
+                .addOnSuccessListener { snapshot ->
+                    continuation.resume(snapshot.getValue(CachedCookingResources::class.java))
+                }
+                .addOnFailureListener { exception ->
+                    Log.e("CookingResourcesRepo", "Error loading cooking resources", exception)
+                    continuation.resumeWithException(exception)
+                }
+        }
+    }
+
+    override suspend fun save(cached: CachedCookingResources) {
+        ref.setValue(cached).await()
+        Log.d("CookingResourcesRepo", "Cooking resources saved successfully")
+    }
+}

--- a/vertexai/app/src/test/kotlin/com/formulae/chef/feature/home/HomeUiStateTest.kt
+++ b/vertexai/app/src/test/kotlin/com/formulae/chef/feature/home/HomeUiStateTest.kt
@@ -1,0 +1,51 @@
+package com.formulae.chef.feature.home
+
+import com.formulae.chef.feature.model.CookingResource
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HomeUiStateTest {
+
+    @Test
+    fun `default state has empty resources and is not loading`() {
+        val state = HomeUiState()
+
+        assertTrue(state.resources.isEmpty())
+        assertFalse(state.isLoading)
+    }
+
+    @Test
+    fun `state with resources exposes them correctly`() {
+        val resources = listOf(
+            CookingResource(title = "Köket.se", url = "https://koket.se", type = "website"),
+            CookingResource(title = "Gordon Ramsay", url = "https://youtube.com/@gordonramsay", type = "youtube")
+        )
+
+        val state = HomeUiState(resources = resources)
+
+        assertEquals(2, state.resources.size)
+        assertEquals("Köket.se", state.resources[0].title)
+        assertEquals("Gordon Ramsay", state.resources[1].title)
+    }
+
+    @Test
+    fun `loading state has isLoading true`() {
+        val state = HomeUiState(isLoading = true)
+
+        assertTrue(state.isLoading)
+        assertTrue(state.resources.isEmpty())
+    }
+
+    @Test
+    fun `copy preserves unchanged fields`() {
+        val resources = listOf(CookingResource(title = "Köket.se", url = "https://koket.se", type = "website"))
+        val state = HomeUiState(resources = resources, isLoading = false)
+
+        val loading = state.copy(isLoading = true)
+
+        assertTrue(loading.isLoading)
+        assertEquals(1, loading.resources.size)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a scrollable "Cooking Resources" section at the bottom of the home/dashboard screen
- Resources (5–8 items per user) are generated by Gemini (`gemini-2.5-flash-lite`) based on user locale and dietary preferences stored in Firebase
- Each resource shows title, type chip (website/youtube/blog/instagram), description, and a tappable URL that opens in the browser
- Results are cached in Firebase at `users/{uid}/cooking_resources` and refreshed after 7 days or when dietary preferences are updated
- Section is hidden for anonymous users
- Home screen layout migrated from centered `Column` → `LazyColumn` to accommodate scrollable content

## New files

- `feature/model/CookingResource.kt` — data model
- `feature/home/HomeUiState.kt` — UI state
- `feature/home/HomeViewModel.kt` — loads/generates resources, caches in Firebase
- `HomeViewModelFactory.kt` — creates Gemini model + ViewModel
- `services/persistence/CookingResourcesRepository.kt` — interface + `CachedCookingResources`
- `services/persistence/CookingResourcesRepositoryImpl.kt` — Firebase impl at `users/{uid}/cooking_resources`
- `feature/home/HomeUiStateTest.kt` — unit tests for UI state

## Setup notes for reviewers

Requires the standard gitignored files: `local.properties`, `google-services.json`, and assets (`chat_system_prompt.txt`, `gcp.json`, `imagen-google-services.json`).

## Test plan

- [x] ktlintCheck passes
- [x] `assembleDebug` builds successfully
- [x] `testDebugUnitTest` passes (25 tests including 4 new `HomeUiStateTest`)
- [x] Sign in → home screen → "Cooking Resources" section appears below navigation buttons with 5–8 personalized items
- [x] Resources show title, type chip, description, and URL in user's locale language (Swedish for Swedish locale)
- [x] Kill + reopen app → logcat shows "Using cached cooking resources" (no regeneration API call)
- [ ] Tap a resource card → browser opens the URL (manual verification needed on device)
- [ ] Anonymous user → resources section not shown (manual verification needed)

Closes CHE-18