### PR TITLE
Humlekottekonsult/che 31 home screen redesign

### DIFF
--- a/vertexai/app/src/main/kotlin/com/formulae/chef/HomeScreen.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/HomeScreen.kt
@@ -1,24 +1,29 @@
 package com.formulae.chef
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Chat
+import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -30,15 +35,27 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import coil.compose.rememberAsyncImagePainter
 import com.formulae.chef.feature.chat.OverlayChatViewModel
 import com.formulae.chef.feature.chat.ui.ChefOverlay
 import com.formulae.chef.feature.collection.ui.DetailRoute
-import com.formulae.chef.feature.collection.ui.RecipeItem
 import com.formulae.chef.feature.home.HomeScreenViewModel
+import com.formulae.chef.feature.model.Recipe
 import com.formulae.chef.services.authentication.UserSessionService
+import com.formulae.chef.ui.components.ChefFab
+import com.formulae.chef.ui.components.RecipeCard
+import com.formulae.chef.ui.components.SectionHeader
+import com.formulae.chef.ui.theme.AppTypography
+import com.formulae.chef.ui.theme.BackgroundColor
+import com.formulae.chef.ui.theme.Terracotta600
+import com.formulae.chef.ui.theme.TextSecondary
+import com.formulae.chef.ui.theme.White
 import com.google.firebase.auth.UserInfo
 
 @Composable
@@ -88,13 +105,14 @@ fun HomeScreen(
                 isOwner = currentUser?.uid == selectedRecipe?.uid
             )
         } else {
+            val firstName = currentUser?.displayName?.split(" ")?.firstOrNull() ?: "Chef"
             HomeScreenContent(
                 viewModel = viewModel,
+                displayName = firstName,
                 onNavigateToChat = onNavigateToChat,
                 onNavigateToCollection = onNavigateToCollection,
                 onNavigateToCommunity = onNavigateToCommunity,
-                onSignOut = onSignOut,
-                signedIn = !userSessionService.anonymousSession && currentUser != null
+                onSignOut = onSignOut
             )
         }
     }
@@ -103,11 +121,11 @@ fun HomeScreen(
 @Composable
 private fun HomeScreenContent(
     viewModel: HomeScreenViewModel,
+    displayName: String,
     onNavigateToChat: () -> Unit,
     onNavigateToCollection: () -> Unit,
     onNavigateToCommunity: () -> Unit,
-    onSignOut: () -> Unit,
-    signedIn: Boolean
+    onSignOut: () -> Unit
 ) {
     val overlayViewModel: OverlayChatViewModel = viewModel(factory = OverlayChatViewModelFactory)
     var showChefOverlay by remember { mutableStateOf(false) }
@@ -116,125 +134,162 @@ private fun HomeScreenContent(
     val communityRecipes by viewModel.communityRecipes.collectAsState()
     val isLoadingRecipes by viewModel.isLoading.collectAsState()
 
-    Scaffold(
-        floatingActionButton = {
-            FloatingActionButton(onClick = { showChefOverlay = true }) {
-                Icon(Icons.Default.Chat, contentDescription = "Chat with Chef")
+    Box(modifier = Modifier.fillMaxSize()) {
+        // Decorative carrot — behind all content, top-right area
+        Image(
+            painter = painterResource(id = R.drawable.carrot),
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .offset(x = 200.dp, y = 24.dp)
+                .width(168.dp)
+                .height(225.dp)
+                .rotate(10.89f)
+                .clip(RoundedCornerShape(16.dp))
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+        ) {
+            // Header block (white background)
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(White)
+                    .padding(horizontal = 16.dp)
+                    .padding(top = 48.dp, bottom = 24.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "Hi, $displayName!",
+                        style = AppTypography.headlineLarge
+                    )
+                    IconButton(onClick = onSignOut) {
+                        Icon(
+                            imageVector = Icons.Outlined.Settings,
+                            contentDescription = "Sign out",
+                            tint = Terracotta600
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Text(
+                    text = "Looking for kitchen inspiration? Chat with Chef to generate your first recipe!",
+                    style = AppTypography.bodyLarge,
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Button(
+                    onClick = onNavigateToChat,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(44.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = Terracotta600),
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Text(
+                        text = "Generate personalized recipes",
+                        style = AppTypography.labelLarge
+                    )
+                }
             }
-        }
-    ) { paddingValues ->
-        if (isLoadingRecipes) {
-            CircularProgressIndicator(
+
+            // Content area
+            Column(
                 modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues)
-                    .wrapContentSize()
-            )
-        } else {
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues)
+                    .fillMaxWidth()
+                    .background(BackgroundColor)
                     .padding(horizontal = 16.dp)
             ) {
-                item {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = "My Recipes",
-                            style = MaterialTheme.typography.titleMedium
-                        )
-                        TextButton(onClick = onNavigateToCollection) {
-                            Text("View all")
-                        }
-                    }
-                }
-
-                if (userRecipes.isEmpty()) {
-                    item {
-                        Text(
-                            text = "No recipes yet. Start chatting to create some!",
-                            style = MaterialTheme.typography.bodyMedium,
-                            modifier = Modifier.padding(vertical = 8.dp)
-                        )
-                    }
-                } else {
-                    items(userRecipes) { recipe ->
-                        RecipeItem(
-                            recipe = recipe,
-                            onRecipeClick = viewModel::onRecipeSelected,
-                            onRecipeRemove = {},
-                            recipeRemoveEnabled = false,
-                            painter = rememberAsyncImagePainter(recipe.imageUrl)
-                        )
-                    }
-                }
-
-                item {
-                    Row(
+                if (isLoadingRecipes) {
+                    Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(top = 16.dp),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
+                            .padding(vertical = 48.dp),
+                        contentAlignment = Alignment.Center
                     ) {
-                        Text(
-                            text = "Community",
-                            style = MaterialTheme.typography.titleMedium
-                        )
-                        TextButton(onClick = onNavigateToCommunity) {
-                            Text("Browse all")
-                        }
-                    }
-                }
-
-                if (communityRecipes.isEmpty()) {
-                    item {
-                        Text(
-                            text = "No community recipes available yet.",
-                            style = MaterialTheme.typography.bodyMedium,
-                            modifier = Modifier.padding(vertical = 8.dp)
-                        )
+                        CircularProgressIndicator()
                     }
                 } else {
-                    items(communityRecipes) { recipe ->
-                        RecipeItem(
-                            recipe = recipe,
-                            onRecipeClick = viewModel::onRecipeSelected,
-                            onRecipeRemove = {},
-                            recipeRemoveEnabled = false,
-                            painter = rememberAsyncImagePainter(recipe.imageUrl)
+                    Spacer(modifier = Modifier.height(24.dp))
+
+                    SectionHeader(
+                        title = "Your saved recipes",
+                        linkText = "All saved recipes",
+                        onLinkClick = onNavigateToCollection
+                    )
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    if (userRecipes.isEmpty()) {
+                        Text(
+                            text = "Start chatting to get personalized recipes!",
+                            style = AppTypography.bodyMedium.copy(color = TextSecondary),
+                            modifier = Modifier.padding(vertical = 8.dp)
+                        )
+                    } else {
+                        RecipeCardGrid(
+                            recipes = userRecipes,
+                            onRecipeClick = viewModel::onRecipeSelected
                         )
                     }
-                }
 
-                item {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 16.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        Button(
-                            onClick = onNavigateToChat,
-                            enabled = signedIn,
-                            modifier = Modifier.padding(4.dp)
-                        ) {
-                            Text(text = "Go to Chat")
-                        }
-                        Button(
-                            onClick = onSignOut,
-                            modifier = Modifier.padding(4.dp)
-                        ) {
-                            Text(text = "Sign out")
-                        }
+                    Spacer(modifier = Modifier.height(24.dp))
+
+                    SectionHeader(
+                        title = "What's cooking?",
+                        linkText = "Community collection",
+                        onLinkClick = onNavigateToCommunity
+                    )
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    if (communityRecipes.isEmpty()) {
+                        Text(
+                            text = "No community recipes yet.",
+                            style = AppTypography.bodyMedium.copy(color = TextSecondary),
+                            modifier = Modifier.padding(vertical = 8.dp)
+                        )
+                    } else {
+                        RecipeCardGrid(
+                            recipes = communityRecipes,
+                            onRecipeClick = viewModel::onRecipeSelected
+                        )
                     }
+
+                    Spacer(modifier = Modifier.height(24.dp))
+
+                    Text(
+                        text = "Chat with Chef, your personal cooking assistant, to generate recipes, " +
+                            "bounce off ideas, or get tips & tricks for your cooking!",
+                        style = AppTypography.bodyMedium.copy(
+                            fontStyle = FontStyle.Italic,
+                            color = TextSecondary
+                        ),
+                        modifier = Modifier.fillMaxWidth()
+                    )
+
+                    Spacer(modifier = Modifier.height(80.dp))
                 }
             }
         }
+
+        ChefFab(
+            onClick = { showChefOverlay = true },
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(end = 16.dp, bottom = 16.dp)
+        )
 
         if (showChefOverlay) {
             ChefOverlay(
@@ -242,6 +297,30 @@ private fun HomeScreenContent(
                 recipe = null,
                 onDismiss = { showChefOverlay = false }
             )
+        }
+    }
+}
+
+@Composable
+private fun RecipeCardGrid(
+    recipes: List<Recipe>,
+    onRecipeClick: (Recipe) -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        recipes.chunked(2).forEach { row ->
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                row.forEach { recipe ->
+                    RecipeCard(
+                        title = recipe.title ?: "",
+                        imageUrl = recipe.imageUrl,
+                        onClick = { onRecipeClick(recipe) },
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+                if (row.size == 1) {
+                    Spacer(modifier = Modifier.weight(1f))
+                }
+            }
         }
     }
 }

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/HomeScreen.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/HomeScreen.kt
@@ -14,7 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material.icons.automirrored.outlined.ExitToApp
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -98,17 +98,12 @@ fun HomeScreen(
                 isOwner = currentUser?.uid == selectedRecipe?.uid
             )
         } else {
-            val firstName = currentUser?.displayName
-                ?.takeIf { it.isNotBlank() }
-                ?.split(" ")?.firstOrNull()
-                ?: currentUser?.email
-                    ?.substringBefore("@")
-                    ?.replaceFirstChar(Char::uppercaseChar)
-                ?: "there"
+            val firstName = remember(currentUser) {
+                resolveDisplayName(currentUser?.displayName, currentUser?.email)
+            }
             HomeScreenContent(
                 viewModel = viewModel,
                 displayName = firstName,
-                onNavigateToChat = onNavigateToChat,
                 onNavigateToCollection = onNavigateToCollection,
                 onNavigateToCommunity = onNavigateToCommunity,
                 onSignOut = onSignOut
@@ -121,7 +116,6 @@ fun HomeScreen(
 private fun HomeScreenContent(
     viewModel: HomeScreenViewModel,
     displayName: String,
-    onNavigateToChat: () -> Unit,
     onNavigateToCollection: () -> Unit,
     onNavigateToCommunity: () -> Unit,
     onSignOut: () -> Unit
@@ -155,7 +149,7 @@ private fun HomeScreenContent(
                 )
                 IconButton(onClick = onSignOut) {
                     Icon(
-                        imageVector = Icons.Outlined.Settings,
+                        imageVector = Icons.AutoMirrored.Outlined.ExitToApp,
                         contentDescription = "Sign out",
                         tint = Terracotta600
                     )
@@ -263,6 +257,7 @@ private fun HomeScreenContent(
 @Composable
 private fun WaveDivider(modifier: Modifier = Modifier) {
     val color = Terracotta200
+    val path = remember { Path() }
     Canvas(
         modifier = modifier
             .fillMaxWidth()
@@ -271,17 +266,17 @@ private fun WaveDivider(modifier: Modifier = Modifier) {
         val waveHeight = 3.dp.toPx()
         val waveLength = 18.dp.toPx()
         val centerY = size.height / 2f
-        val path = Path()
+        path.reset()
         path.moveTo(0f, centerY)
         var x = 0f
         while (x < size.width + waveLength) {
-            path.quadraticBezierTo(
+            path.quadraticTo(
                 x + waveLength / 4f,
                 centerY - waveHeight,
                 x + waveLength / 2f,
                 centerY
             )
-            path.quadraticBezierTo(
+            path.quadraticTo(
                 x + waveLength * 3f / 4f,
                 centerY + waveHeight,
                 x + waveLength,
@@ -316,3 +311,8 @@ private fun RecipeCardGrid(
         }
     }
 }
+
+internal fun resolveDisplayName(displayName: String?, email: String?): String =
+    displayName?.takeIf { it.isNotBlank() }?.split(" ")?.firstOrNull()
+        ?: email?.substringBefore("@")?.replaceFirstChar(Char::uppercaseChar)
+        ?: "there"

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/HomeScreen.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/HomeScreen.kt
@@ -1,5 +1,6 @@
 package com.formulae.chef
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -15,7 +16,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
@@ -30,6 +30,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -98,7 +100,11 @@ fun HomeScreen(
         } else {
             val firstName = currentUser?.displayName
                 ?.takeIf { it.isNotBlank() }
-                ?.split(" ")?.firstOrNull() ?: "Chef"
+                ?.split(" ")?.firstOrNull()
+                ?: currentUser?.email
+                    ?.substringBefore("@")
+                    ?.replaceFirstChar(Char::uppercaseChar)
+                ?: "there"
             HomeScreenContent(
                 viewModel = viewModel,
                 displayName = firstName,
@@ -155,7 +161,7 @@ private fun HomeScreenContent(
                     )
                 }
             }
-            HorizontalDivider(color = Terracotta200)
+            WaveDivider()
 
             // Content area
             Column(
@@ -251,6 +257,39 @@ private fun HomeScreenContent(
                 onDismiss = { showChefOverlay = false }
             )
         }
+    }
+}
+
+@Composable
+private fun WaveDivider(modifier: Modifier = Modifier) {
+    val color = Terracotta200
+    Canvas(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(14.dp)
+    ) {
+        val waveHeight = 3.dp.toPx()
+        val waveLength = 18.dp.toPx()
+        val centerY = size.height / 2f
+        val path = Path()
+        path.moveTo(0f, centerY)
+        var x = 0f
+        while (x < size.width + waveLength) {
+            path.quadraticBezierTo(
+                x + waveLength / 4f,
+                centerY - waveHeight,
+                x + waveLength / 2f,
+                centerY
+            )
+            path.quadraticBezierTo(
+                x + waveLength * 3f / 4f,
+                centerY + waveHeight,
+                x + waveLength,
+                centerY
+            )
+            x += waveLength
+        }
+        drawPath(path, color = color, style = Stroke(width = 1.5.dp.toPx()))
     }
 }
 

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/HomeScreen.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/HomeScreen.kt
@@ -1,6 +1,5 @@
 package com.formulae.chef
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -10,17 +9,13 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Settings
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
@@ -35,10 +30,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -53,9 +44,9 @@ import com.formulae.chef.ui.components.RecipeCard
 import com.formulae.chef.ui.components.SectionHeader
 import com.formulae.chef.ui.theme.AppTypography
 import com.formulae.chef.ui.theme.BackgroundColor
+import com.formulae.chef.ui.theme.Terracotta200
 import com.formulae.chef.ui.theme.Terracotta600
 import com.formulae.chef.ui.theme.TextSecondary
-import com.formulae.chef.ui.theme.White
 import com.google.firebase.auth.UserInfo
 
 @Composable
@@ -105,7 +96,9 @@ fun HomeScreen(
                 isOwner = currentUser?.uid == selectedRecipe?.uid
             )
         } else {
-            val firstName = currentUser?.displayName?.split(" ")?.firstOrNull() ?: "Chef"
+            val firstName = currentUser?.displayName
+                ?.takeIf { it.isNotBlank() }
+                ?.split(" ")?.firstOrNull() ?: "Chef"
             HomeScreenContent(
                 viewModel = viewModel,
                 displayName = firstName,
@@ -135,74 +128,34 @@ private fun HomeScreenContent(
     val isLoadingRecipes by viewModel.isLoading.collectAsState()
 
     Box(modifier = Modifier.fillMaxSize()) {
-        // Decorative carrot — behind all content, top-right area
-        Image(
-            painter = painterResource(id = R.drawable.carrot),
-            contentDescription = null,
-            contentScale = ContentScale.Crop,
-            modifier = Modifier
-                .offset(x = 200.dp, y = 24.dp)
-                .width(168.dp)
-                .height(225.dp)
-                .rotate(10.89f)
-                .clip(RoundedCornerShape(16.dp))
-        )
-
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
         ) {
-            // Header block (white background)
-            Column(
+            // Greeting header
+            Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(White)
+                    .background(BackgroundColor)
                     .padding(horizontal = 16.dp)
-                    .padding(top = 48.dp, bottom = 24.dp)
+                    .padding(top = 48.dp, bottom = 16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        text = "Hi, $displayName!",
-                        style = AppTypography.headlineLarge
-                    )
-                    IconButton(onClick = onSignOut) {
-                        Icon(
-                            imageVector = Icons.Outlined.Settings,
-                            contentDescription = "Sign out",
-                            tint = Terracotta600
-                        )
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(24.dp))
-
                 Text(
-                    text = "Looking for kitchen inspiration? Chat with Chef to generate your first recipe!",
-                    style = AppTypography.bodyLarge,
-                    modifier = Modifier.fillMaxWidth()
+                    text = "Hi, $displayName!",
+                    style = AppTypography.headlineLarge
                 )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Button(
-                    onClick = onNavigateToChat,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(44.dp),
-                    colors = ButtonDefaults.buttonColors(containerColor = Terracotta600),
-                    shape = RoundedCornerShape(8.dp)
-                ) {
-                    Text(
-                        text = "Generate personalized recipes",
-                        style = AppTypography.labelLarge
+                IconButton(onClick = onSignOut) {
+                    Icon(
+                        imageVector = Icons.Outlined.Settings,
+                        contentDescription = "Sign out",
+                        tint = Terracotta600
                     )
                 }
             }
+            HorizontalDivider(color = Terracotta200)
 
             // Content area
             Column(

--- a/vertexai/app/src/main/kotlin/com/formulae/chef/ui/components/ChefFab.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/ui/components/ChefFab.kt
@@ -2,6 +2,8 @@ package com.formulae.chef.ui.components
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.FloatingActionButton
@@ -9,6 +11,7 @@ import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -37,7 +40,10 @@ fun ChefFab(
         Image(
             painter = painterResource(R.drawable.logo),
             contentDescription = "Generate recipe",
-            modifier = Modifier.size(28.dp)
+            contentScale = ContentScale.Fit,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(4.dp)
         )
     }
 }

--- a/vertexai/app/src/test/kotlin/com/formulae/chef/ResolveDisplayNameTest.kt
+++ b/vertexai/app/src/test/kotlin/com/formulae/chef/ResolveDisplayNameTest.kt
@@ -1,0 +1,37 @@
+package com.formulae.chef
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ResolveDisplayNameTest {
+
+    @Test
+    fun `returns first name when displayName is set`() {
+        assertEquals("Jane", resolveDisplayName("Jane Doe", null))
+    }
+
+    @Test
+    fun `returns single-token displayName as-is`() {
+        assertEquals("Jane", resolveDisplayName("Jane", null))
+    }
+
+    @Test
+    fun `falls back to capitalised email prefix when displayName is null`() {
+        assertEquals("Jane", resolveDisplayName(null, "jane@example.com"))
+    }
+
+    @Test
+    fun `falls back to capitalised email prefix when displayName is blank`() {
+        assertEquals("Jane", resolveDisplayName("  ", "jane@example.com"))
+    }
+
+    @Test
+    fun `returns there when both displayName and email are null`() {
+        assertEquals("there", resolveDisplayName(null, null))
+    }
+
+    @Test
+    fun `returns there when displayName is blank and email is null`() {
+        assertEquals("there", resolveDisplayName("  ", null))
+    }
+}


### PR DESCRIPTION
 ## Summary

  - Remove nested `Scaffold` from `HomeScreen.kt` (violates CLAUDE.md no-nested-scaffolds rule)
  - Greeting header: `"Hi, $firstName!"` using Firebase `displayName`, falling back to email prefix if not set
  - Wavy Canvas divider (`Terracotta200`) separating header from content sections
  - Replace old `RecipeItem` list with 2-column `RecipeCardGrid` using shared `RecipeCard` component
  - Wire `SectionHeader` for "Your saved recipes" (→ collection) and "What's cooking?" (→ community)
  - `ChefFab` overlaid via `Box.align(BottomEnd)` — no longer in a Scaffold FAB slot
  - FAB icon: `fillMaxSize + ContentScale.Fit + padding(4dp)` so logo renders fully without cropping
  - Replace old `RecipeItem` list with 2-column `RecipeCardGrid` using shared `RecipeCard` component
  - Wire `SectionHeader` for "Your saved recipes" (→ collection) and "What's cooking?" (→ community)
  - `ChefFab` overlaid via `Box.align(BottomEnd)` — no longer in a Scaffold FAB slot         
  - FAB icon: `fillMaxSize + ContentScale.Fit + padding(4dp)` so logo renders fully without cropping
  - Bottom descriptive chat text per Figma
              
  **Scoped out:** The Figma node (28:6326 "Home first visit") includes a description text and
  "Generate personalized recipes" CTA button. These are deferred — see CHE-31 comment for rationale.
                                                      
  ## Test plan                                            
                                                                     
  - [x] `./gradlew ktlintCheck` passes                
  - [x] `./gradlew :vertexai:app:assembleDebug` passes                            
  - [x] `./gradlew :vertexai:app:testDebugUnitTest` passes                        
  - [x] Greeting shows name from displayName or email prefix fallback
  - [x] Wavy terracotta divider visible below greeting
  - [x] "Your saved recipes" 2-column card grid + "All saved recipes →" link works
  - [x] "What's cooking?" 2-column card grid + "Community collection →" link works
  - [x] Settings icon triggers sign-out
  - [x] ChefFab tapping opens Chef overlay
  - [x] Bottom nav Home tab selected, no double padding

  Closes CHE-31