### PR TITLE
CHE-32: Generate (Chat) screen redesign

### DIFF
--- a/vertexai/app/src/main/kotlin/com/formulae/chef/feature/chat/ui/ChatScreen.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/feature/chat/ui/ChatScreen.kt
@@ -17,6 +17,7 @@
 package com.formulae.chef.feature.chat.ui
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -24,32 +25,35 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
+import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MicOff
-import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.ThumbUp
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
+import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -62,11 +66,15 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -79,6 +87,14 @@ import com.formulae.chef.feature.chat.ChatViewModel
 import com.formulae.chef.feature.collection.ui.DetailRoute
 import com.formulae.chef.feature.model.Recipe
 import com.formulae.chef.services.voice.sanitizeMarkdown
+import com.formulae.chef.ui.components.ChefTopBar
+import com.formulae.chef.ui.theme.AppTypography
+import com.formulae.chef.ui.theme.BackgroundColor
+import com.formulae.chef.ui.theme.Terracotta100
+import com.formulae.chef.ui.theme.Terracotta200
+import com.formulae.chef.ui.theme.Terracotta600
+import com.formulae.chef.ui.theme.TextPrimary
+import com.formulae.chef.ui.theme.TextSecondary
 import kotlinx.coroutines.launch
 
 @Composable
@@ -130,44 +146,60 @@ private fun ChatContent(chatViewModel: ChatViewModel) {
         }
     }
 
-    Scaffold(
-        bottomBar = {
-            MessageInput(
-                onSendMessage = { inputText ->
-                    chatViewModel.sendMessage(inputText)
-                },
-                resetScroll = {
-                    coroutineScope.launch { listState.scrollToItem(0) }
-                },
-                isRecording = voice.isRecording,
-                onStartRecording = voice.onStartRecording
-            )
-        }
-    ) { paddingValues ->
-        Column(
-            modifier = Modifier
-                .padding(paddingValues)
-                .fillMaxSize()
-        ) {
-            if (isLoading) {
-                CircularProgressIndicator(
-                    modifier = Modifier.align(Alignment.CenterHorizontally)
-                )
-            } else {
-                ChatList(
-                    chatMessages = chatUiState.messages,
-                    listState = listState,
-                    onStarClicked = chatViewModel::onRecipeStarred,
-                    onLikeClicked = chatViewModel::onMessageLiked,
-                    onRecipeClick = chatViewModel::onRecipeSelectedFromChat,
-                    onRecipeStarredFromGrid = { messageId, recipe ->
-                        chatViewModel.onRecipeStarredFromGrid(messageId, recipe)
-                    },
-                    speakingMessageId = voice.speakingMessageId,
-                    onSpeakClicked = voice.onSpeakClicked
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .imePadding()
+    ) {
+        ChefTopBar(
+            title = "Chat with Chef",
+            navigationIcon = {
+                Image(
+                    painter = painterResource(R.drawable.logo),
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .size(32.dp)
+                        .clip(CircleShape)
                 )
             }
+        )
+
+        if (isLoading) {
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        } else {
+            ChatList(
+                chatMessages = chatUiState.messages,
+                listState = listState,
+                onStarClicked = chatViewModel::onRecipeStarred,
+                onLikeClicked = chatViewModel::onMessageLiked,
+                onRecipeClick = chatViewModel::onRecipeSelectedFromChat,
+                onRecipeStarredFromGrid = { messageId, recipe ->
+                    chatViewModel.onRecipeStarredFromGrid(messageId, recipe)
+                },
+                speakingMessageId = voice.speakingMessageId,
+                onSpeakClicked = voice.onSpeakClicked,
+                modifier = Modifier.weight(1f)
+            )
         }
+
+        MessageInput(
+            onSendMessage = { inputText ->
+                chatViewModel.sendMessage(inputText)
+            },
+            resetScroll = {
+                coroutineScope.launch { listState.scrollToItem(0) }
+            },
+            isRecording = voice.isRecording,
+            onStartRecording = voice.onStartRecording
+        )
     }
 }
 
@@ -180,12 +212,13 @@ fun ChatList(
     onRecipeClick: (Recipe) -> Unit,
     onRecipeStarredFromGrid: (String, Recipe) -> Unit,
     speakingMessageId: String? = null,
-    onSpeakClicked: ((ChatMessage) -> Unit)? = null
+    onSpeakClicked: ((ChatMessage) -> Unit)? = null,
+    modifier: Modifier = Modifier
 ) {
     LazyColumn(
         reverseLayout = true,
         state = listState,
-        modifier = Modifier.fillMaxSize()
+        modifier = modifier.fillMaxWidth()
     ) {
         items(chatMessages.reversed(), key = { it.id }) { message ->
             ChatBubbleItem(
@@ -219,115 +252,119 @@ fun ChatBubbleItem(
     Column(
         horizontalAlignment = horizontalAlignment,
         modifier = Modifier
-            .padding(horizontal = 8.dp, vertical = 4.dp)
+            .padding(horizontal = 16.dp, vertical = 4.dp)
             .fillMaxWidth()
     ) {
-        Text(
-            text = chatMessage.participant.name,
-            style = MaterialTheme.typography.bodySmall,
-            modifier = Modifier.padding(bottom = 4.dp)
-        )
-
-        if (chatMessage.recipes.isNotEmpty()) {
-            RecipeGrid(
-                recipes = chatMessage.recipes,
-                starredRecipeIds = chatMessage.starredRecipeIds,
-                failedImageRecipeIds = chatMessage.failedImageRecipeIds,
-                onRecipeClick = onRecipeClick,
-                onStarClick = { recipe -> onRecipeStarredFromGrid(chatMessage.id, recipe) }
-            )
-        } else {
-            val backgroundColor = when (chatMessage.participant) {
-                Participant.MODEL -> MaterialTheme.colorScheme.primaryContainer
-                Participant.USER -> MaterialTheme.colorScheme.tertiaryContainer
-                Participant.ERROR -> MaterialTheme.colorScheme.errorContainer
+        when {
+            chatMessage.recipes.isNotEmpty() -> {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    if (chatMessage.text.isNotBlank()) {
+                        Text(
+                            text = chatMessage.text.sanitizeMarkdown(),
+                            style = AppTypography.bodyLarge.copy(color = TextPrimary),
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                    chatMessage.recipes.forEach { recipe ->
+                        ChatRecipeCard(
+                            recipe = recipe,
+                            isStarred = recipe.id in chatMessage.starredRecipeIds,
+                            isImageFailed = recipe.id != null &&
+                                recipe.id in chatMessage.failedImageRecipeIds,
+                            onClick = { onRecipeClick(recipe) },
+                            onStarClick = { onRecipeStarredFromGrid(chatMessage.id, recipe) }
+                        )
+                    }
+                }
             }
 
-            val bubbleShape = if (isModelMessage) {
-                RoundedCornerShape(4.dp, 20.dp, 20.dp, 20.dp)
-            } else {
-                RoundedCornerShape(20.dp, 4.dp, 20.dp, 20.dp)
-            }
-
-            Row {
-                if (chatMessage.isPending) {
-                    CircularProgressIndicator(
-                        modifier = Modifier
-                            .align(Alignment.CenterVertically)
-                            .padding(all = 8.dp)
+            chatMessage.participant == Participant.USER -> {
+                Box(
+                    modifier = Modifier
+                        .background(Terracotta200, RoundedCornerShape(8.dp))
+                        .padding(8.dp)
+                ) {
+                    Text(
+                        text = chatMessage.text,
+                        style = AppTypography.bodyLarge.copy(color = TextPrimary)
                     )
                 }
-                Column {
-                    Card(
-                        colors = CardDefaults.cardColors(containerColor = backgroundColor),
-                        shape = bubbleShape,
+            }
+
+            chatMessage.participant == Participant.ERROR -> {
+                Box(
+                    modifier = Modifier
+                        .background(
+                            MaterialTheme.colorScheme.errorContainer,
+                            RoundedCornerShape(8.dp)
+                        )
+                        .padding(8.dp)
+                        .fillMaxWidth()
+                ) {
+                    Text(
+                        text = chatMessage.text,
+                        style = AppTypography.bodyLarge.copy(
+                            color = MaterialTheme.colorScheme.onErrorContainer
+                        )
+                    )
+                }
+            }
+
+            else -> {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    if (chatMessage.isPending) {
+                        CircularProgressIndicator(
+                            modifier = Modifier
+                                .size(16.dp)
+                                .padding(end = 8.dp),
+                            strokeWidth = 2.dp
+                        )
+                    }
+                    Text(
+                        text = chatMessage.text.sanitizeMarkdown(),
+                        style = AppTypography.bodyLarge.copy(color = TextPrimary),
                         modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Column(modifier = Modifier.padding(16.dp)) {
-                            Text(
-                                modifier = Modifier.fillMaxWidth(),
-                                text = chatMessage.text.sanitizeMarkdown()
+                    )
+                }
+                if (!chatMessage.isPending) {
+                    Row {
+                        IconButton(
+                            onClick = { onLikeClicked(chatMessage) },
+                            modifier = Modifier.size(36.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.ThumbUp,
+                                contentDescription = if (chatMessage.isLiked) {
+                                    "Liked"
+                                } else {
+                                    "Like response"
+                                },
+                                tint = if (chatMessage.isLiked) Terracotta600 else TextSecondary,
+                                modifier = Modifier.size(18.dp)
                             )
                         }
-                        Spacer(modifier = Modifier.height(8.dp))
-                    }
-                    if (chatMessage.participant == Participant.MODEL) {
-                        Card(
-                            colors = CardDefaults.cardColors(containerColor = backgroundColor),
-                            shape = bubbleShape,
-                            modifier = Modifier.fillMaxWidth()
-                        ) {
-                            Row(modifier = Modifier.fillMaxWidth()) {
-                                IconButton(
-                                    onClick = { onLikeClicked(chatMessage) }
-                                ) {
-                                    Icon(
-                                        imageVector = Icons.Default.ThumbUp,
-                                        contentDescription = if (chatMessage.isLiked) {
-                                            "Liked"
-                                        } else {
-                                            "Like response"
-                                        },
-                                        tint = if (chatMessage.isLiked) {
-                                            MaterialTheme.colorScheme.primary
-                                        } else {
-                                            Color.Gray
-                                        }
-                                    )
-                                }
-                                if (onSpeakClicked != null && chatMessage.text.isNotBlank()) {
-                                    IconButton(
-                                        onClick = { onSpeakClicked(chatMessage) }
-                                    ) {
-                                        Icon(
-                                            imageVector = Icons.AutoMirrored.Filled.VolumeUp,
-                                            contentDescription = if (isSpeakingThisMessage) {
-                                                "Stop reading"
-                                            } else {
-                                                "Read response aloud"
-                                            },
-                                            tint = if (isSpeakingThisMessage) {
-                                                MaterialTheme.colorScheme.primary
-                                            } else {
-                                                Color.Gray
-                                            }
-                                        )
-                                    }
-                                }
-                                Spacer(modifier = Modifier.weight(1f))
-                                IconButton(
-                                    onClick = { onStarClicked(chatMessage) }
-                                ) {
-                                    Icon(
-                                        imageVector = Icons.Default.Star,
-                                        contentDescription = if (chatMessage.isStarred) {
-                                            "Remove recipe from collection"
-                                        } else {
-                                            "Save recipe to collection"
-                                        },
-                                        tint = if (chatMessage.isStarred) Color.Yellow else Color.Gray
-                                    )
-                                }
+                        if (onSpeakClicked != null && chatMessage.text.isNotBlank()) {
+                            IconButton(
+                                onClick = { onSpeakClicked(chatMessage) },
+                                modifier = Modifier.size(36.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.AutoMirrored.Filled.VolumeUp,
+                                    contentDescription = if (isSpeakingThisMessage) {
+                                        "Stop reading"
+                                    } else {
+                                        "Read response aloud"
+                                    },
+                                    tint = if (isSpeakingThisMessage) {
+                                        Terracotta600
+                                    } else {
+                                        TextSecondary
+                                    },
+                                    modifier = Modifier.size(18.dp)
+                                )
                             }
                         }
                     }
@@ -338,97 +375,101 @@ fun ChatBubbleItem(
 }
 
 @Composable
-private fun RecipeGrid(
-    recipes: List<Recipe>,
-    starredRecipeIds: Set<String>,
-    failedImageRecipeIds: Set<String>,
-    onRecipeClick: (Recipe) -> Unit,
-    onStarClick: (Recipe) -> Unit
-) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 4.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        recipes.chunked(3).forEach { rowRecipes ->
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                rowRecipes.forEach { recipe ->
-                    RecipeSuggestionCard(
-                        recipe = recipe,
-                        isStarred = recipe.id in starredRecipeIds,
-                        isImageFailed = recipe.id != null && recipe.id in failedImageRecipeIds,
-                        onRecipeClick = { onRecipeClick(recipe) },
-                        onStarClick = { onStarClick(recipe) },
-                        modifier = Modifier.weight(1f)
-                    )
-                }
-                if (recipes.size >= 3) {
-                    repeat(3 - rowRecipes.size) {
-                        Spacer(modifier = Modifier.weight(1f))
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun RecipeSuggestionCard(
+private fun ChatRecipeCard(
     recipe: Recipe,
     isStarred: Boolean,
     isImageFailed: Boolean,
-    onRecipeClick: () -> Unit,
+    onClick: () -> Unit,
     onStarClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Card(
-        modifier = modifier.clickable { onRecipeClick() }
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(104.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(Terracotta100)
+            .clickable(onClick = onClick)
     ) {
-        Column {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(100.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                if (recipe.imageUrl != null) {
+        Box(
+            modifier = Modifier
+                .width(140.dp)
+                .fillMaxHeight()
+                .background(Color.White)
+        ) {
+            when {
+                recipe.imageUrl != null -> {
                     Image(
                         painter = rememberAsyncImagePainter(recipe.imageUrl),
                         contentDescription = recipe.title,
-                        modifier = Modifier.fillMaxSize(),
-                        contentScale = ContentScale.Crop
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize()
                     )
-                } else if (isImageFailed) {
+                }
+                isImageFailed -> {
                     Text(
                         text = "Image unavailable",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        style = AppTypography.bodySmall.copy(color = TextSecondary),
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .padding(8.dp)
                     )
-                } else {
-                    CircularProgressIndicator()
+                }
+                else -> {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .size(24.dp)
+                            .align(Alignment.Center),
+                        strokeWidth = 2.dp,
+                        color = Terracotta600
+                    )
                 }
             }
-            Text(
-                text = recipe.title,
-                style = MaterialTheme.typography.bodySmall,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.padding(horizontal = 6.dp, vertical = 4.dp)
-            )
-            IconButton(
-                onClick = onStarClick,
-                modifier = Modifier.align(Alignment.End)
+            Box(
+                modifier = Modifier
+                    .padding(8.dp)
+                    .size(32.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(BackgroundColor)
+                    .align(Alignment.TopStart)
+                    .clickable(onClick = onStarClick),
+                contentAlignment = Alignment.Center
             ) {
                 Icon(
-                    imageVector = Icons.Default.Star,
-                    contentDescription = if (isStarred) "Remove from collection" else "Save to collection",
-                    tint = if (isStarred) Color.Yellow else Color.Gray
+                    imageVector = if (isStarred) {
+                        Icons.Default.Bookmark
+                    } else {
+                        Icons.Outlined.BookmarkBorder
+                    },
+                    contentDescription = if (isStarred) {
+                        "Remove from collection"
+                    } else {
+                        "Save to collection"
+                    },
+                    tint = Terracotta600,
+                    modifier = Modifier.size(20.dp)
                 )
             }
+        }
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight()
+                .padding(12.dp)
+        ) {
+            Text(
+                text = recipe.title ?: "",
+                style = AppTypography.labelMedium.copy(
+                    fontWeight = FontWeight.Bold,
+                    fontStyle = FontStyle.Italic,
+                    color = TextPrimary
+                ),
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            // TODO: ratings and save count (no model support yet)
         }
     }
 }
@@ -442,21 +483,24 @@ fun MessageInput(
 ) {
     var userMessage by rememberSaveable { mutableStateOf("") }
     val keyboardController = LocalSoftwareKeyboardController.current
-    ElevatedCard(
-        modifier = Modifier
-            .padding(bottom = 40.dp)
-            .fillMaxWidth()
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = Color.White,
+        shape = RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp),
+        shadowElevation = 4.dp
     ) {
         Row(
             modifier = Modifier
-                .padding(16.dp)
+                .padding(horizontal = 8.dp, vertical = 10.dp)
                 .fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Box(
                 modifier = Modifier
-                    .weight(0.12f)
-                    .padding(4.dp)
+                    .size(36.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(BackgroundColor)
                     .pointerInput(Unit) {
                         detectTapGestures(onLongPress = { onStartRecording() })
                     },
@@ -465,20 +509,28 @@ fun MessageInput(
                 Icon(
                     imageVector = if (isRecording) Icons.Default.MicOff else Icons.Default.Mic,
                     contentDescription = if (isRecording) "Recording…" else "Hold to speak",
-                    tint = if (isRecording) MaterialTheme.colorScheme.error else Color.Gray
+                    tint = if (isRecording) Terracotta600 else TextSecondary,
+                    modifier = Modifier.size(20.dp)
                 )
             }
+
             OutlinedTextField(
                 value = userMessage,
-                label = { Text(stringResource(R.string.chat_label)) },
+                placeholder = {
+                    Text(
+                        text = stringResource(R.string.chat_label),
+                        style = AppTypography.bodyLarge.copy(color = TextSecondary)
+                    )
+                },
                 onValueChange = { userMessage = it },
                 keyboardOptions = KeyboardOptions(
                     capitalization = KeyboardCapitalization.Sentences
                 ),
                 modifier = Modifier
-                    .align(Alignment.CenterVertically)
-                    .weight(0.73f)
+                    .weight(1f)
+                    .padding(horizontal = 8.dp)
             )
+
             IconButton(
                 onClick = {
                     if (userMessage.isNotBlank()) {
@@ -487,15 +539,12 @@ fun MessageInput(
                         resetScroll()
                         keyboardController?.hide()
                     }
-                },
-                modifier = Modifier
-                    .padding(start = 16.dp)
-                    .align(Alignment.CenterVertically)
-                    .weight(0.15f)
+                }
             ) {
                 Icon(
                     Icons.AutoMirrored.Filled.Send,
-                    contentDescription = stringResource(R.string.action_send)
+                    contentDescription = stringResource(R.string.action_send),
+                    tint = if (userMessage.isNotBlank()) Terracotta600 else TextSecondary
                 )
             }
         }
@@ -528,18 +577,16 @@ fun PreviewMessageInput() {
     MessageInput(onSendMessage = {})
 }
 
-@Preview(showBackground = true, name = "Recipe Grid – 5 suggestions")
+@Preview(showBackground = true, name = "Recipe Cards – 2 suggestions")
 @Composable
-fun PreviewRecipeGrid() {
+fun PreviewRecipeCards() {
     val recipes = listOf(
         Recipe(id = "1", title = "West African Peanut Stew", imageUrl = null),
-        Recipe(id = "2", title = "Pasta Carbonara", imageUrl = null),
-        Recipe(id = "3", title = "Chicken Tikka Masala", imageUrl = null),
-        Recipe(id = "4", title = "Beef Rendang", imageUrl = null),
-        Recipe(id = "5", title = "Coq au Vin", imageUrl = null)
+        Recipe(id = "2", title = "Pasta Carbonara", imageUrl = null)
     )
     ChatBubbleItem(
         chatMessage = ChatMessage(
+            text = "Here are some ideas:",
             participant = Participant.MODEL,
             recipes = recipes,
             starredRecipeIds = setOf("2")


### PR DESCRIPTION
## Summary

- Removes nested `Scaffold` from `ChatContent` (CLAUDE.md no-nested-scaffold rule) — replaced with `Column + imePadding()` for keyboard handling
- Adds `ChefTopBar` with Chef logo (circular, 32dp) + "Chat with Chef" title; no search icon (feature doesn't exist yet)
- User messages: right-aligned Terracotta200 pill with `bodyLarge` text, participant label removed
- Model messages: plain left-aligned `bodyLarge` text (no bubble card), with small like + speak icon row below
- Replaces 3-column `RecipeGrid` with full-width horizontal `ChatRecipeCard` (Terracotta100 bg, image left 140dp, title + TODO rating/count right)
- Bookmark icon overlaid on recipe card image (filled when starred, outlined when not) — taps save to collection
- `MessageInput` redesigned with `Surface` + rounded top corners + shadow elevation, design tokens throughout (Terracotta600 for active states, TextSecondary for idle)

## Notes for reviewers

- Ratings and save-count row on recipe cards are deferred (TODO comment left) — no model support yet
- Gitignored assets needed to build: `local.properties`, `vertexai/app/google-services.json`, `vertexai/app/src/main/assets/`

## Test plan

- [x] `ktlintCheck` passes
- [x] `:vertexai:app:assembleDebug` passes
- [x] `:vertexai:app:testDebugUnitTest` passes
- [x] Navigate to Generate tab — top bar shows logo + "Chat with Chef", no search icon
- [x] Send a message — user bubble appears right-aligned, Terracotta200 background, no "USER" label
- [x] Model response — plain text left-aligned, like + speak icons below
- [x] Recipe card — horizontal full-width card (image left, title right, bookmark icon overlay)
- [x] Tap recipe card → opens Recipe Detail
- [x] Bookmark icon on recipe card → saves/removes from collection
- [x] Speak icon → TTS plays response
- [x] Like icon → marks response as liked
- [x] Mic long-press → voice recording starts
- [ ] MessageInput stays above keyboard when typing
- [x] Bottom nav shows Generate tab selected, no double padding

Closes CHE-32