### PR TITLE
#35: Use Play Integrity App Check provider for release builds

### DIFF
--- a/vertexai/app/src/main/kotlin/com/formulae/chef/MainActivity.kt
+++ b/vertexai/app/src/main/kotlin/com/formulae/chef/MainActivity.kt
@@ -31,6 +31,7 @@ import com.formulae.chef.ui.theme.GenerativeAISample
 import com.google.firebase.Firebase
 import com.google.firebase.appcheck.appCheck
 import com.google.firebase.appcheck.debug.DebugAppCheckProviderFactory
+import com.google.firebase.appcheck.playintegrity.PlayIntegrityAppCheckProviderFactory
 import com.google.firebase.initialize
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
@@ -44,9 +45,15 @@ class MainActivity : ComponentActivity() {
 
     init {
         Firebase.initialize(context = this)
-        Firebase.appCheck.installAppCheckProviderFactory(
+        // Debug provider keeps local dev builds / directly-installed test builds working without
+        // per-device Play Integrity setup. Play Integrity is required for release so App Check
+        // provides real abuse protection once Firebase enforces it for AI Logic (Nov 2, 2026).
+        val appCheckProviderFactory = if (BuildConfig.DEBUG) {
             DebugAppCheckProviderFactory.getInstance()
-        )
+        } else {
+            PlayIntegrityAppCheckProviderFactory.getInstance()
+        }
+        Firebase.appCheck.installAppCheckProviderFactory(appCheckProviderFactory)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
## Summary

- Firebase will auto-enforce App Check for all Firebase AI Logic (Gemini) requests starting **Nov 2, 2026**. Requests without a valid App Check token will be rejected after that date.
- `MainActivity` already depended on both the Play Integrity and Debug App Check providers, but only ever installed the Debug provider — including in release builds. Debug tokens require manual per-device registration and don't attest device/app integrity, so this isn't a supported production setup.
- This PR installs `PlayIntegrityAppCheckProviderFactory` for release builds and keeps `DebugAppCheckProviderFactory` for debug builds, so local dev and directly-installed test builds (the project's actual test-distribution flow, per `adb install app-debug.apk`) keep working with no extra setup.

## Setup notes for reviewers

No new gitignored config keys or files are required — the `firebase-appcheck-playintegrity` dependency was already declared in `build.gradle.kts`, just unused until now.

## Remaining manual steps (Firebase Console, not code)

- [ ] Register the release build's SHA-256 signing certificate fingerprint in Firebase project settings so Play Integrity verdicts resolve. Note: `build.gradle.kts` currently has no `signingConfigs`/`buildTypes` block, so `assembleRelease` isn't signed with a real release key yet — that's a prerequisite gap to close first.
- [ ] Review App Check adoption metrics in Firebase Console and enforce App Check for the Gemini API ahead of the Nov 2, 2026 deadline.

## Test plan

- [x] `./gradlew ktlintCheck` — passes
- [x] `./gradlew :vertexai:app:assembleDebug` — passes
- [x] `./gradlew :vertexai:app:testDebugUnitTest` — passes
- [x] Installed the debug APK on a connected device, launched the app: no crash, process stays alive, no App Check errors in logcat/crash buffer — debug path behavior unchanged.
- [x] Release-path (Play Integrity) behavior is not buildable/testable in this environment — no release signing config exists yet and real verification requires a Play Console-registered fingerprint. Deferred to manual verification once the console setup above is complete.

No new unit test was added: `MainActivity` has a Firebase/Android `Context` constructor dependency that can't be injected/faked (same category as `ChatViewModel`/`SignInViewModel`, which CLAUDE.md exempts from the mandatory-test rule), and the change is a one-line build-type branch with no independently testable logic.

Closes #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
